### PR TITLE
feat: add system data cleanup features to reduce macOS storage

### DIFF
--- a/check-storage.sh
+++ b/check-storage.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+echo "🔍 Checking System Data Storage..."
+echo ""
+
+echo "📱 iOS Backups:"
+du -sh ~/Library/Application\ Support/MobileSync/Backup 2>/dev/null || echo "None found"
+echo ""
+
+echo "🐳 Docker Storage:"
+docker system df 2>/dev/null || echo "Docker not installed"
+echo ""
+
+echo "⏰ Time Machine Local Snapshots:"
+tmutil listlocalsnapshots / 2>/dev/null | wc -l | xargs echo "Snapshots count:"
+echo ""
+
+echo "📧 Mail Data:"
+du -sh ~/Library/Mail 2>/dev/null || echo "None found"
+du -sh ~/Library/Mail\ Downloads 2>/dev/null || echo "None found"
+echo ""
+
+echo "💿 macOS Installers:"
+du -sh /Applications/Install\ macOS*.app 2>/dev/null || echo "None found"
+du -sh ~/Library/Updates 2>/dev/null || echo "None found"
+echo ""
+
+echo "🎵 Spotify Cache:"
+du -sh ~/Library/Caches/com.spotify.client 2>/dev/null || echo "None found"
+echo ""
+
+echo "📦 Largest directories in ~/Library:"
+du -sh ~/Library/* 2>/dev/null | sort -hr | head -10


### PR DESCRIPTION
This update significantly enhances the dev-cleaner tool with new capabilities to reduce macOS System Data storage.

New Features:
- Enhanced Xcode cleanup: Now removes Archives, build Products, and DocumentationCache
- New cleanup_android_sdk(): Removes old Android SDK build-tools (keeps latest 2), removes x86 emulator images on ARM Macs
- New cleanup_app_containers(): Cleans caches for Slack, Teams, WhatsApp, Discord, and Spotify
- New cleanup_timemachine_snapshots(): Removes Time Machine local snapshots to free space
- Added check-storage.sh utility script to analyze storage usage

Menu Updates:
- Added option 12: Clean Android SDK (old build-tools, x86 images)
- Added option 13: Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)
- Added option 14: Remove Time Machine Local Snapshots
- Updated option 1 to include all new cleanup functions
- Updated menu prompt to reflect new options (0-14)

Improvements:
- CoreDevice cache cleanup integrated into Xcode cleanup (can free ~2.6GB)
- Xcode cleanup now more comprehensive (can free additional 5-10GB)
- Android SDK cleanup helps manage 16GB SDK installations
- App containers cleanup targets high-usage apps (Slack ~1.8GB, Teams ~500MB)

Version: 1.0.1 → 1.1.0