### PR TITLE
feat: estimate reclaimable space before cleaning (menu option 99)

### DIFF
--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -20,6 +20,10 @@ $GITHUB_REPO = "https://github.com/jemishavasoya/dev-cleaner"
 # --- Error Tracking ---
 $script:FailedItems = [System.Collections.ArrayList]::new()
 
+# --- Estimation state ---
+$script:Estimates = @{}
+$script:EstimatesReady = $false
+
 # --- Helper Functions ---
 
 function Show-Logo {
@@ -67,6 +71,53 @@ function Get-DiskSpace {
         return "$freeGB GB"
     }
     return "Unknown"
+}
+
+# --- Estimation helpers (read-only: never delete anything) ---
+
+function Get-PathSizeBytes {
+    param([string[]]$Paths)
+    [int64]$total = 0
+    foreach ($pattern in $Paths) {
+        if ([string]::IsNullOrWhiteSpace($pattern)) { continue }
+        $items = Get-Item -Path $pattern -Force -ErrorAction SilentlyContinue
+        foreach ($item in $items) {
+            try {
+                if ($item.PSIsContainer) {
+                    $sum = (Get-ChildItem -LiteralPath $item.FullName -Recurse -Force -File -ErrorAction SilentlyContinue |
+                            Measure-Object -Property Length -Sum).Sum
+                    if ($sum) { $total += [int64]$sum }
+                } else {
+                    $total += [int64]$item.Length
+                }
+            } catch { }
+        }
+    }
+    return $total
+}
+
+function Format-Size {
+    param([int64]$Bytes)
+    if ($Bytes -ge 1GB)     { return ("{0:N1} GB" -f ($Bytes / 1GB)) }
+    elseif ($Bytes -ge 1MB) { return ("{0:N1} MB" -f ($Bytes / 1MB)) }
+    elseif ($Bytes -ge 1KB) { return ("{0:N0} KB" -f ($Bytes / 1KB)) }
+    else                    { return ("{0} B" -f $Bytes) }
+}
+
+function Set-Estimate {
+    param([string]$Key, [string]$Label)
+    $script:Estimates[$Key] = $Label
+}
+
+# Returns " (Estimate: <label>)" for a stable category key, or "" if not yet
+# computed. Keys are strings (not menu numbers) so renumbering stays safe.
+function Get-Est {
+    param([string]$Key)
+    if (-not $script:EstimatesReady) { return "" }
+    if ($script:Estimates.ContainsKey($Key) -and $script:Estimates[$Key]) {
+        return " (Estimate: $($script:Estimates[$Key]))"
+    }
+    return ""
 }
 
 # --- Admin Elevation Functions ---
@@ -543,6 +594,170 @@ function Clear-AppContainers {
     }
 }
 
+# --- Reclaimable-space estimation ---
+# Read-only: computes the current on-disk size of what each cleanup option
+# would remove, then Show-Menu shows it next to each entry. Categories use
+# stable string keys so the menu can be renumbered safely.
+# IMPORTANT: keep these path lists in sync with the Clear-* functions above.
+
+function Invoke-EstimateAll {
+    Write-Item "🔍" "Cyan" "Calculating estimates... (this can take a while)"
+    [int64]$total = 0
+    [int64]$b = 0
+
+    # Visual Studio - global caches only (~); project bin/obj/.vs not scanned
+    Write-Host "  Measuring Visual Studio caches..." -ForegroundColor DarkGray
+    $vsPaths = @()
+    $vsVersions = Get-ChildItem -Path "$env:LOCALAPPDATA\Microsoft\VisualStudio" -Directory -ErrorAction SilentlyContinue
+    foreach ($v in $vsVersions) {
+        $vsPaths += "$($v.FullName)\ComponentModelCache"
+        $vsPaths += "$($v.FullName)\MEFCacheData"
+        $vsPaths += "$($v.FullName)\Designer\ShadowCache"
+        $vsPaths += "$($v.FullName)\ImageLibrary"
+    }
+    $b = Get-PathSizeBytes $vsPaths
+    Set-Estimate "visualstudio" ("~" + (Format-Size $b)); $total += $b
+
+    # Android / Gradle
+    Write-Host "  Measuring Android/Gradle caches..." -ForegroundColor DarkGray
+    $b = Get-PathSizeBytes @(
+        "$env:USERPROFILE\.gradle\caches",
+        "$env:USERPROFILE\.gradle\daemon",
+        "$env:LOCALAPPDATA\Google\AndroidStudio*",
+        "$env:LOCALAPPDATA\JetBrains\AndroidStudio*"
+    )
+    Set-Estimate "android" (Format-Size $b); $total += $b
+
+    # Android SDK - old build-tools (keep latest 2) + .temp
+    Write-Host "  Measuring Android SDK..." -ForegroundColor DarkGray
+    $sdkPath = "$env:LOCALAPPDATA\Android\Sdk"
+    $sdkPaths = @("$sdkPath\.temp")
+    $btPath = "$sdkPath\build-tools"
+    if (Test-Path $btPath) {
+        $old = Get-ChildItem -Path $btPath -Directory -ErrorAction SilentlyContinue |
+               Sort-Object Name -Descending | Select-Object -Skip 2
+        foreach ($o in $old) { $sdkPaths += $o.FullName }
+    }
+    $b = Get-PathSizeBytes $sdkPaths
+    Set-Estimate "androidsdk" (Format-Size $b); $total += $b
+
+    # Flutter - global cache only (~)
+    Write-Host "  Measuring Flutter global cache..." -ForegroundColor DarkGray
+    $flPaths = @("$env:LOCALAPPDATA\Pub\Cache", "$env:APPDATA\Pub\Cache")
+    $fcmd = Get-Command flutter -ErrorAction SilentlyContinue
+    if ($fcmd) {
+        $fbin = Split-Path $fcmd.Source -Parent
+        if ($fbin) { $flPaths += (Join-Path $fbin "cache") }
+    }
+    $b = Get-PathSizeBytes $flPaths
+    Set-Estimate "flutter" ("~" + (Format-Size $b)); $total += $b
+
+    # npm / Yarn / pnpm (~)
+    Write-Host "  Measuring npm/Yarn/pnpm caches..." -ForegroundColor DarkGray
+    $npmPaths = @("$env:LOCALAPPDATA\pnpm\store", "$env:LOCALAPPDATA\pnpm-cache")
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        $nc = (npm config get cache 2>$null | Select-Object -First 1)
+        if ($nc) { $nc = "$nc".Trim() }
+        if ($nc -and $nc -ne "undefined" -and $nc -ne "null") { $npmPaths += (Join-Path $nc "_cacache") }
+    }
+    if (Get-Command yarn -ErrorAction SilentlyContinue) {
+        $yd = (yarn cache dir 2>$null | Select-Object -First 1)
+        if ($yd) { $npmPaths += "$yd".Trim() }
+    }
+    if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+        $pd = (pnpm store path 2>$null | Select-Object -First 1)
+        if ($pd) { $npmPaths += "$pd".Trim() }
+    }
+    $b = Get-PathSizeBytes $npmPaths
+    Set-Estimate "npm" ("~" + (Format-Size $b)); $total += $b
+
+    # NuGet
+    Write-Host "  Measuring NuGet caches..." -ForegroundColor DarkGray
+    $b = Get-PathSizeBytes @(
+        "$env:USERPROFILE\.nuget\packages",
+        "$env:LOCALAPPDATA\NuGet\v3-cache",
+        "$env:LOCALAPPDATA\NuGet\plugins-cache",
+        "$env:TEMP\NuGetScratch"
+    )
+    Set-Estimate "nuget" (Format-Size $b); $total += $b
+
+    # PlatformIO - global cache only (~)
+    Write-Host "  Measuring PlatformIO global cache..." -ForegroundColor DarkGray
+    $b = Get-PathSizeBytes @("$env:USERPROFILE\.platformio\.cache")
+    Set-Estimate "platformio" ("~" + (Format-Size $b)); $total += $b
+
+    # IDE caches (JetBrains + VSCode)
+    Write-Host "  Measuring IDE caches..." -ForegroundColor DarkGray
+    $idePaths = @(
+        "$env:APPDATA\Code\Cache",
+        "$env:APPDATA\Code\CachedData",
+        "$env:APPDATA\Code\User\workspaceStorage",
+        "$env:APPDATA\Code - Insiders\Cache",
+        "$env:APPDATA\Code - Insiders\CachedData"
+    )
+    $jb = Get-ChildItem -Path "$env:LOCALAPPDATA\JetBrains" -Directory -ErrorAction SilentlyContinue
+    foreach ($j in $jb) {
+        $idePaths += "$($j.FullName)\caches"
+        $idePaths += "$($j.FullName)\index"
+        $idePaths += "$($j.FullName)\tmp"
+    }
+    $b = Get-PathSizeBytes $idePaths
+    Set-Estimate "ide" (Format-Size $b); $total += $b
+
+    # Windows Temp (~) - Recycle Bin / admin system temp not measured
+    Write-Host "  Measuring Windows temp..." -ForegroundColor DarkGray
+    $b = Get-PathSizeBytes @("$env:TEMP", "$env:LOCALAPPDATA\Temp")
+    Set-Estimate "windowstemp" ("~" + (Format-Size $b)); $total += $b
+
+    # Browser caches
+    Write-Host "  Measuring browser caches..." -ForegroundColor DarkGray
+    $brPaths = @(
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cache",
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Code Cache",
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cache",
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Code Cache",
+        "$env:LOCALAPPDATA\BraveSoftware\Brave-Browser\User Data\Default\Cache",
+        "$env:LOCALAPPDATA\BraveSoftware\Brave-Browser\User Data\Default\Code Cache",
+        "$env:APPDATA\Opera Software\Opera Stable\Cache",
+        "$env:APPDATA\Opera Software\Opera GX Stable\Cache"
+    )
+    $ffProfiles = "$env:LOCALAPPDATA\Mozilla\Firefox\Profiles"
+    if (Test-Path $ffProfiles) {
+        $profs = Get-ChildItem -Path $ffProfiles -Directory -ErrorAction SilentlyContinue
+        foreach ($p in $profs) { $brPaths += "$($p.FullName)\cache2" }
+    }
+    $b = Get-PathSizeBytes $brPaths
+    Set-Estimate "browser" (Format-Size $b); $total += $b
+
+    # App containers
+    Write-Host "  Measuring app caches..." -ForegroundColor DarkGray
+    $acPaths = @(
+        "$env:APPDATA\Slack\Cache",
+        "$env:APPDATA\Slack\Service Worker\CacheStorage",
+        "$env:APPDATA\Microsoft\Teams\Cache",
+        "$env:APPDATA\Microsoft\Teams\blob_storage",
+        "$env:APPDATA\Microsoft\Teams\databases",
+        "$env:APPDATA\Microsoft\Teams\GPUCache",
+        "$env:APPDATA\Microsoft\Teams\IndexedDB",
+        "$env:APPDATA\Microsoft\Teams\Local Storage",
+        "$env:APPDATA\Microsoft\Teams\tmp",
+        "$env:LOCALAPPDATA\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams",
+        "$env:APPDATA\discord\Cache",
+        "$env:APPDATA\discord\Code Cache",
+        "$env:LOCALAPPDATA\Spotify\Storage",
+        "$env:APPDATA\Spotify",
+        "$env:LOCALAPPDATA\WhatsApp\Cache"
+    )
+    $waUwp = Get-ChildItem -Path "$env:LOCALAPPDATA\Packages" -Filter "*WhatsApp*" -Directory -ErrorAction SilentlyContinue
+    foreach ($w in $waUwp) { $acPaths += "$($w.FullName)\LocalCache" }
+    $b = Get-PathSizeBytes $acPaths
+    Set-Estimate "appcontainers" (Format-Size $b); $total += $b
+
+    Set-Estimate "total" ("~" + (Format-Size $total))
+    $script:EstimatesReady = $true
+    Write-Item "✓" "Green" "Estimates ready. ~ marks approximate values."
+}
+
 # --- Menu Display ---
 
 function Show-Menu {
@@ -555,24 +770,26 @@ function Show-Menu {
     Write-Host ""
     Write-SectionHeader "Available Options:"
     Write-Host " 0. Exit Program" -ForegroundColor Red
-    Write-Host " 1. Clear All Caches" -ForegroundColor Green
+    Write-Host (" 1. Clear All Caches" + (Get-Est 'total')) -ForegroundColor Green
     Write-Host "─── Development Tools ───" -ForegroundColor DarkGray
-    Write-Host " 2. Clear Visual Studio Caches (bin/obj/.vs + global)" -ForegroundColor Green
-    Write-Host " 3. Clear Android/Gradle Caches" -ForegroundColor Green
-    Write-Host " 4. Clear Android SDK (old build-tools)" -ForegroundColor Green
+    Write-Host (" 2. Clear Visual Studio Caches (bin/obj/.vs + global)" + (Get-Est 'visualstudio')) -ForegroundColor Green
+    Write-Host (" 3. Clear Android/Gradle Caches" + (Get-Est 'android')) -ForegroundColor Green
+    Write-Host (" 4. Clear Android SDK (old build-tools)" + (Get-Est 'androidsdk')) -ForegroundColor Green
     Write-Host " 5. Clear Flutter Caches " -NoNewline -ForegroundColor Green
-    Write-Host "(with custom directory option)" -ForegroundColor DarkGray
-    Write-Host " 6. Clear npm/Yarn/pnpm Caches" -ForegroundColor Green
-    Write-Host " 7. Clear NuGet Package Cache" -ForegroundColor Green
-    Write-Host " 8. Clear PlatformIO Caches" -ForegroundColor Green
+    Write-Host ("(with custom directory option)" + (Get-Est 'flutter')) -ForegroundColor DarkGray
+    Write-Host (" 6. Clear npm/Yarn/pnpm Caches" + (Get-Est 'npm')) -ForegroundColor Green
+    Write-Host (" 7. Clear NuGet Package Cache" + (Get-Est 'nuget')) -ForegroundColor Green
+    Write-Host (" 8. Clear PlatformIO Caches" + (Get-Est 'platformio')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
-    Write-Host " 9. Clear IDE Caches (JetBrains, VSCode)" -ForegroundColor Green
+    Write-Host (" 9. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
-    Write-Host "10. Clean Windows Temp & Recycle Bin" -ForegroundColor Green
-    Write-Host "11. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" -ForegroundColor Green
-    Write-Host "12. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" -ForegroundColor Green
+    Write-Host ("10. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
+    Write-Host ("11. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
+    Write-Host ("12. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
     Write-Host ""
-    Write-Host "→ Please enter your choice (0-12): " -NoNewline
+    Write-Host "99. Estimate reclaimable space (read-only, ~ = approximate)" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "→ Please enter your choice (0-12, or 99 to estimate): " -NoNewline
 }
 
 # --- Main Loop ---
@@ -676,6 +893,13 @@ function Start-MainLoop {
                 Write-SectionHeader "Performing App Caches Cleanup"
                 Clear-AppContainers
             }
+            "99" {
+                Write-SectionHeader "Estimating Reclaimable Space"
+                Invoke-EstimateAll
+                # Read-only: skip the before/after summary and redraw the menu
+                # with the freshly computed estimates.
+                continue
+            }
             default {
                 Write-Host "Invalid choice. Please enter a number between 0 and 12." -ForegroundColor Red
                 Start-Sleep -Seconds 2
@@ -713,6 +937,12 @@ Options:
                       Example: .\dev-cleaner.ps1 -FlutterDir "C:\Projects"
   -VsDir PATH         Set custom directory for Visual Studio cleanup (default: current directory)
                       Example: .\dev-cleaner.ps1 -VsDir "C:\Projects\DotNet"
+
+Interactive menu:
+  Option 99 estimates the reclaimable space for every entry and redraws the
+  menu with "(Estimate: <size>)". It is read-only (deletes nothing). A leading
+  "~" marks an approximate value; Flutter, PlatformIO and Visual Studio
+  estimates cover the global cache only.
 
 Examples:
   .\dev-cleaner.ps1                                    # Run interactive menu

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -87,6 +87,74 @@ get_disk_space() {
     df -h . | awk 'NR==2 {print $4}'
 }
 
+# --- Estimation helpers (read-only: never delete anything) ---
+
+# Format a size given in KB into a human-readable string using the same
+# binary units as `df -h` on macOS (Gi/Mi/Ki), so the estimate matches the
+# "Free Space" figure shown at the top of the menu.
+human_kb() {
+    awk -v kb="${1:-0}" 'BEGIN {
+        if (kb >= 1048576)      printf "%.1fGi", kb / 1048576;
+        else if (kb >= 1024)    printf "%.1fMi", kb / 1024;
+        else                    printf "%dKi", kb;
+    }'
+}
+
+# Sum the disk usage (in KB) of the given paths/globs. Read-only.
+# Glob handling mirrors safe_rm() so the estimate matches what cleanup deletes.
+# Usage: du_kb_sum <path-or-glob> [<path-or-glob> ...]
+du_kb_sum() {
+    local total=0 path expanded_path kb
+    local expanded_paths=()
+    for path in "$@"; do
+        expanded_paths=()
+        shopt -s nullglob
+        if [[ "$path" == *\** || "$path" == *\?* ]]; then
+            # Intentional glob expansion (same pattern as safe_rm)
+            # shellcheck disable=SC2206
+            expanded_paths=($path)
+        else
+            expanded_paths=("$path")
+        fi
+        shopt -u nullglob
+
+        for expanded_path in "${expanded_paths[@]}"; do
+            if [[ -e "$expanded_path" ]]; then
+                kb=$(du -sk "$expanded_path" 2>/dev/null | awk '{print $1}')
+                [[ -n "$kb" ]] && total=$((total + kb))
+            fi
+        done
+    done
+    echo "$total"
+}
+
+# Same as du_kb_sum but for paths that require elevated privileges.
+# The sudo session is already kept alive by main_loop(), so no extra prompt.
+sudo_du_kb_sum() {
+    local total=0 path expanded_path kb
+    local expanded_paths=()
+    for path in "$@"; do
+        expanded_paths=()
+        shopt -s nullglob
+        if [[ "$path" == *\** || "$path" == *\?* ]]; then
+            # Intentional glob expansion (same pattern as safe_sudo_rm)
+            # shellcheck disable=SC2206
+            expanded_paths=($path)
+        else
+            expanded_paths=("$path")
+        fi
+        shopt -u nullglob
+
+        for expanded_path in "${expanded_paths[@]}"; do
+            if [[ -e "$expanded_path" ]] || sudo test -e "$expanded_path" 2>/dev/null; then
+                kb=$(sudo du -sk "$expanded_path" 2>/dev/null | awk '{print $1}')
+                [[ -n "$kb" ]] && total=$((total + kb))
+            fi
+        done
+    done
+    echo "$total"
+}
+
 # Dry-run aware file/directory removal
 # Usage: safe_rm [-r] <path> [<path> ...]
 safe_rm() {
@@ -529,6 +597,186 @@ cleanup_timemachine_snapshots() {
     fi
 }
 
+# --- Reclaimable-space estimation ---
+# Read-only feature: computes the current on-disk size of what every cleanup
+# option would remove, then display_menu() shows it next to each entry.
+# Categories use STABLE string keys (not menu numbers) so the estimate keeps
+# working when the menu is renumbered by later PRs.
+# IMPORTANT: keep these path lists in sync with the cleanup_* functions above.
+# Any new cleanup routine must add its own category to estimate_all() and a
+# matching $(est <key>) in display_menu().
+
+ESTIMATES_READY=false
+
+# Store a formatted estimate label under a stable category key.
+set_estimate() {
+    printf -v "EST_${1}_LABEL" '%s' "$2"
+}
+
+# Echo " (Estimate: <label>)" for a category key, or nothing if not computed.
+est() {
+    [ "$ESTIMATES_READY" = "true" ] || return 0
+    local varname="EST_${1}_LABEL"
+    local label="${!varname}"
+    [ -n "$label" ] || return 0
+    printf ' %s(Estimate: %s)%s' "$FAINT" "$label" "$NC"
+}
+
+estimate_all() {
+    print_item "🔍" "${CYAN}" "Calculating estimates... (this can take a while)"
+
+    local kb total=0
+
+    print_item "•" "${FAINT}" "Measuring Xcode caches..."
+    kb=$(du_kb_sum \
+        "$HOME/Library/Developer/Xcode/DerivedData" \
+        "$HOME/Library/Developer/CoreSimulator/Devices" \
+        "$HOME/Library/Developer/Xcode/iOS DeviceSupport" \
+        "$HOME/Library/Caches/com.apple.dt.Xcode" \
+        "$HOME/Library/Developer/Xcode/Archives" \
+        "$HOME/Library/Developer/Xcode/Products" \
+        "$HOME/Library/Developer/Xcode/DocumentationCache" \
+        "$HOME/Library/Containers/com.apple.CoreDevice.CoreDeviceService/Data/Library/Caches"/*)
+    set_estimate xcode "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Measuring Android/Gradle caches..."
+    kb=$(du_kb_sum \
+        "$HOME/.gradle/caches" \
+        "$HOME/.gradle/daemon" \
+        "$HOME/Library/Caches/Google"/AndroidStudio* \
+        "$HOME/Library/Caches/JetBrains"/AndroidStudio*)
+    set_estimate android "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Measuring Android SDK..."
+    local sdk_kb=0 d
+    if [ -d "$HOME/Library/Android/sdk/build-tools" ]; then
+        # Mirrors cleanup_android_sdk: keep latest 2 build-tools by mtime.
+        # SDK version dir names are plain (e.g. 34.0.0), ls -t is safe here.
+        # shellcheck disable=SC2012
+        while IFS= read -r d; do
+            [ -n "$d" ] || continue
+            sdk_kb=$((sdk_kb + $(du_kb_sum "$HOME/Library/Android/sdk/build-tools/$d")))
+        done < <(cd "$HOME/Library/Android/sdk/build-tools" 2>/dev/null && ls -t | tail -n +3)
+    fi
+    sdk_kb=$((sdk_kb + $(du_kb_sum "$HOME/Library/Android/sdk/.temp")))
+    if [ "$(uname -m)" = "arm64" ]; then
+        while IFS= read -r d; do
+            [ -n "$d" ] || continue
+            sdk_kb=$((sdk_kb + $(du_kb_sum "$d")))
+        done < <(find "$HOME/Library/Android/sdk/system-images" -type d -name "x86" 2>/dev/null)
+    fi
+    set_estimate android_sdk "$(human_kb "$sdk_kb")"
+    total=$((total + sdk_kb))
+
+    print_item "•" "${FAINT}" "Measuring Flutter global cache..."
+    local flutter_kb froot
+    flutter_kb=$(du_kb_sum "$HOME/.pub-cache")
+    if command -v flutter >/dev/null 2>&1; then
+        froot="$(cd "$(dirname "$(command -v flutter)")" 2>/dev/null && pwd)"
+        [ -n "$froot" ] && flutter_kb=$((flutter_kb + $(du_kb_sum "$froot/cache")))
+    fi
+    set_estimate flutter "~$(human_kb "$flutter_kb")"
+    total=$((total + flutter_kb))
+
+    print_item "•" "${FAINT}" "Measuring npm/Yarn/pnpm caches..."
+    local npm_kb npm_cache yarn_dir pnpm_dir
+    npm_cache=""
+    command -v npm >/dev/null 2>&1 && npm_cache="$(npm config get cache 2>/dev/null)"
+    case "$npm_cache" in ""|undefined|null) npm_cache="$HOME/.npm" ;; esac
+    npm_kb=$(du_kb_sum "$npm_cache/_cacache")
+    if command -v yarn >/dev/null 2>&1; then
+        yarn_dir="$(yarn cache dir 2>/dev/null)"
+        [ -n "$yarn_dir" ] && npm_kb=$((npm_kb + $(du_kb_sum "$yarn_dir")))
+    fi
+    if command -v pnpm >/dev/null 2>&1; then
+        pnpm_dir="$(pnpm store path 2>/dev/null)"
+        [ -n "$pnpm_dir" ] && npm_kb=$((npm_kb + $(du_kb_sum "$pnpm_dir")))
+    fi
+    set_estimate npm "~$(human_kb "$npm_kb")"
+    total=$((total + npm_kb))
+
+    print_item "•" "${FAINT}" "Measuring Homebrew cache..."
+    local brew_kb=0 brew_cache
+    if command -v brew >/dev/null 2>&1; then
+        brew_cache="$(brew --cache 2>/dev/null)"
+        [ -n "$brew_cache" ] && brew_kb=$(du_kb_sum "$brew_cache")
+    fi
+    set_estimate homebrew "~$(human_kb "$brew_kb")"
+    total=$((total + brew_kb))
+
+    print_item "•" "${FAINT}" "Measuring CocoaPods cache..."
+    kb=$(du_kb_sum \
+        "$HOME/.cocoapods/repos" \
+        "$HOME/Library/Caches/CocoaPods")
+    set_estimate cocoapods "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Measuring IDE caches..."
+    kb=$(du_kb_sum \
+        "$HOME/Library/Caches/JetBrains" \
+        "$HOME/Library/Application Support/Code/Cache" \
+        "$HOME/Library/Application Support/Code/CachedData" \
+        "$HOME/Library/Application Support/Code/User/workspaceStorage")
+    set_estimate ide "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Measuring system junk & logs (sudo)..."
+    local system_kb
+    system_kb=$(sudo_du_kb_sum \
+        "$HOME/.Trash"/* \
+        /Volumes/*/.Trashes/* \
+        /Library/Caches/* \
+        "$HOME/Library/Logs"/* \
+        /private/var/log/* \
+        /Library/Logs/*)
+    set_estimate system "~$(human_kb "$system_kb")"
+    total=$((total + system_kb))
+
+    print_item "•" "${FAINT}" "Measuring browser caches..."
+    kb=$(du_kb_sum \
+        "$HOME/Library/Caches/Google/Chrome"/* \
+        "$HOME/Library/Caches/BraveSoftware/Brave-Browser"/* \
+        "$HOME/Library/Caches/Firefox"/* \
+        "$HOME/Library/Caches/com.apple.Safari"/* \
+        "$HOME/Library/Caches/Microsoft Edge"/* \
+        "$HOME/Library/Caches/com.microsoft.edgemac"/* \
+        "$HOME/Library/Caches/com.operasoftware.Opera"/* \
+        "$HOME/Library/Caches/com.operasoftware.OperaGX"/*)
+    set_estimate browser "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Measuring PlatformIO global cache..."
+    local pio_kb
+    pio_kb=$(du_kb_sum "$HOME/.platformio/.cache")
+    set_estimate platformio "~$(human_kb "$pio_kb")"
+    total=$((total + pio_kb))
+
+    print_item "•" "${FAINT}" "Measuring app container caches..."
+    kb=$(du_kb_sum \
+        "$HOME/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Caches"/* \
+        "$HOME/Library/Containers/com.microsoft.teams2/Data/Library/Caches"/* \
+        "$HOME/Library/Containers/net.whatsapp.WhatsApp/Data/Library/Caches"/* \
+        "$HOME/Library/Application Support/discord/Cache"/* \
+        "$HOME/Library/Application Support/discord/Code Cache"/* \
+        "$HOME/Library/Caches/com.spotify.client"/* \
+        "$HOME/Library/Application Support/Spotify/PersistentCache"/*)
+    set_estimate appcontainers "$(human_kb "$kb")"
+    total=$((total + kb))
+
+    print_item "•" "${FAINT}" "Counting Time Machine local snapshots..."
+    local tm_count
+    tm_count=$(sudo tmutil listlocalsnapshots / 2>/dev/null | grep -c 'com.apple.TimeMachine')
+    [ -n "$tm_count" ] || tm_count=0
+    set_estimate timemachine "${tm_count} snapshot(s)"
+
+    set_estimate total "~$(human_kb "$total")"
+    ESTIMATES_READY=true
+
+    print_item "✓" "${GREEN}" "Estimates ready. ~ marks approximate values."
+}
+
 # --- Main Display Function ---
 display_menu() {
     clear
@@ -540,22 +788,24 @@ display_menu() {
     echo ""
     print_section_header "Available Options:"
     echo -e "${RED} 0.${NC} ${BOLD}Exit Program${NC}"
-    echo -e "${GREEN} 1.${NC} Clear All Caches"
-    echo -e "${GREEN} 2.${NC} Clear Xcode Caches & DerivedData"
-    echo -e "${GREEN} 3.${NC} Clear Android/Gradle Caches"
-    echo -e "${GREEN} 4.${NC} Clear Flutter Caches ${FAINT}(with custom directory option)${NC}"
-    echo -e "${GREEN} 5.${NC} Clear npm/Yarn/pnpm Caches"
-    echo -e "${GREEN} 6.${NC} Clean Homebrew Caches"
-    echo -e "${GREEN} 7.${NC} Clear CocoaPods Caches"
-    echo -e "${GREEN} 8.${NC} Clear IDE (JetBrains, VSCode) Caches"
-    echo -e "${GREEN} 9.${NC} Clean System Junk & Logs (requires sudo)"
-    echo -e "${GREEN}10.${NC} Clear Browser Caches (Chrome, Brave, Firefox, Safari, Edge, Opera)"
-    echo -e "${GREEN}11.${NC} Clear PlatformIO Caches"
-    echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)"
-    echo -e "${GREEN}13.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)"
-    echo -e "${GREEN}14.${NC} Remove Time Machine Local Snapshots (requires sudo)"
+    echo -e "${GREEN} 1.${NC} Clear All Caches$(est total)"
+    echo -e "${GREEN} 2.${NC} Clear Xcode Caches & DerivedData$(est xcode)"
+    echo -e "${GREEN} 3.${NC} Clear Android/Gradle Caches$(est android)"
+    echo -e "${GREEN} 4.${NC} Clear Flutter Caches ${FAINT}(with custom directory option)${NC}$(est flutter)"
+    echo -e "${GREEN} 5.${NC} Clear npm/Yarn/pnpm Caches$(est npm)"
+    echo -e "${GREEN} 6.${NC} Clean Homebrew Caches$(est homebrew)"
+    echo -e "${GREEN} 7.${NC} Clear CocoaPods Caches$(est cocoapods)"
+    echo -e "${GREEN} 8.${NC} Clear IDE (JetBrains, VSCode) Caches$(est ide)"
+    echo -e "${GREEN} 9.${NC} Clean System Junk & Logs (requires sudo)$(est system)"
+    echo -e "${GREEN}10.${NC} Clear Browser Caches (Chrome, Brave, Firefox, Safari, Edge, Opera)$(est browser)"
+    echo -e "${GREEN}11.${NC} Clear PlatformIO Caches$(est platformio)"
+    echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)$(est android_sdk)"
+    echo -e "${GREEN}13.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
+    echo -e "${GREEN}14.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo ""
-    echo -e "→ Please enter your choice (0-14): ${NC}\c"
+    echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
+    echo ""
+    echo -e "→ Please enter your choice (0-14, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -576,6 +826,12 @@ Options:
 Command-line Flutter cleanup:
   You can specify a custom directory for Flutter cleanup using the --flutter-dir option.
   This directory will be used when running the interactive menu or the "Clear All" option.
+
+Interactive menu:
+  Option 99 estimates the reclaimable space for every entry and redraws the
+  menu with "(Estimate: <size>)". It is read-only (only runs 'du', deletes
+  nothing) and works in --dry-run too. A leading "~" marks an approximate
+  value; Flutter and PlatformIO estimates cover the global cache only.
 
 Examples:
   $0                                    # Run interactive menu (searches current directory for Flutter projects)
@@ -717,6 +973,13 @@ main_loop() {
             14)
                 print_section_header "Performing Time Machine Snapshots Cleanup"
                 cleanup_timemachine_snapshots
+                ;;
+            99)
+                print_section_header "Estimating Reclaimable Space"
+                estimate_all
+                # Read-only: skip the before/after summary and redraw the menu
+                # with the freshly computed estimates.
+                continue
                 ;;
             *)
                 echo -e "${RED}Invalid choice. Please enter a number between 0 and 14.${NC}"


### PR DESCRIPTION
Closes #44

## What

Adds a **read-only** menu option **`99`** that estimates how much disk space
each cleanup entry would free, then redraws the menu with
`(Estimate: <size>)` next to every option and a total on *Clear All*.

## Why

The tool only shows total free space and a before/after figure. There was no
way to see *which* options are worth running, or how much each would reclaim,
before deleting anything.

## How

- **Strictly read-only**: only runs `du` (bash) / `Measure-Object`
  (PowerShell). Deletes nothing; behaves identically under `--dry-run`.
- Per-entry estimate mirrors exactly the paths the matching cleanup routine
  would remove (kept in a dedicated, commented section).
- Best-effort for tool-managed caches (npm/yarn/pnpm, Homebrew, …) via their
  known cache dirs; approximate values are prefixed with `~`.
- Flutter and PlatformIO cover the **global cache only** (fast, deterministic,
  no recursive project scan); Time Machine reports the local snapshot count.
- macOS sizes use the same binary units as `df -h` (`Gi/Mi/Ki`) so the
  estimate matches the existing "Free Space" figure.
- Implemented in **both** `dev-cleaner.sh` and `dev-cleaner.ps1`.
- Option `99` is intentionally non-contiguous and categories use stable
  string keys, so existing options `0-N`, the "Invalid choice" message and
  any future menu renumbering are unaffected.

## Testing

- `bash -n dev-cleaner.sh`: passes.
- `shellcheck dev-cleaner.sh`: no new findings introduced by this change
  (only pre-existing, unrelated warnings remain; the two intentional
  glob-expansion lines mirror `safe_rm` and carry a scoped
  `# shellcheck disable` with a reason).
- Unit tests of the helpers (`human_kb`, `du_kb_sum`, `est`) and an
  end-to-end `estimate_all` run against a sandboxed `$HOME`: all 14
  categories + total populated, approximations marked `~`, Time Machine as
  a count, and a before/after filesystem snapshot confirming **nothing is
  deleted** (read-only guarantee, identical under `--dry-run`).
- `dev-cleaner.ps1`: feature implemented at parity (no PowerShell available
  on the dev machine to execute it locally — Windows validation by reviewers
  welcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)