### PR TITLE
feat: add Cordova tmp cleanup routine

### DIFF
--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -594,6 +594,21 @@ function Clear-AppContainers {
     }
 }
 
+function Clear-Cordova {
+    $cordovaPath = "$env:USERPROFILE\.cordova"
+
+    if (Test-Path $cordovaPath) {
+        Write-Item "✓" "Green" "Cleaning Cordova tmp files..."
+        # Cordova leaves stale npm tarballs/extractions under lib\tmp*
+        $tmpDirs = Get-ChildItem -Path "$cordovaPath\lib" -Filter "tmp*" -Force -ErrorAction SilentlyContinue
+        foreach ($d in $tmpDirs) {
+            Remove-SafelyWithTracking -Path $d.FullName -Description "Cordova tmp: $($d.Name)"
+        }
+    } else {
+        Write-Item "✕" "Yellow" "Cordova not found. Skipping."
+    }
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only: computes the current on-disk size of what each cleanup option
 # would remove, then Show-Menu shows it next to each entry. Categories use
@@ -729,6 +744,14 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes $brPaths
     Set-Estimate "browser" (Format-Size $b); $total += $b
 
+    # Cordova tmp files
+    Write-Host "  Measuring Cordova tmp files..." -ForegroundColor DarkGray
+    $cordovaTmp = @()
+    $cordovaDirs = Get-ChildItem -Path "$env:USERPROFILE\.cordova\lib" -Filter "tmp*" -Force -ErrorAction SilentlyContinue
+    foreach ($t in $cordovaDirs) { $cordovaTmp += $t.FullName }
+    $b = Get-PathSizeBytes $cordovaTmp
+    Set-Estimate "cordova" (Format-Size $b); $total += $b
+
     # App containers
     Write-Host "  Measuring app caches..." -ForegroundColor DarkGray
     $acPaths = @(
@@ -780,16 +803,17 @@ function Show-Menu {
     Write-Host (" 6. Clear npm/Yarn/pnpm Caches" + (Get-Est 'npm')) -ForegroundColor Green
     Write-Host (" 7. Clear NuGet Package Cache" + (Get-Est 'nuget')) -ForegroundColor Green
     Write-Host (" 8. Clear PlatformIO Caches" + (Get-Est 'platformio')) -ForegroundColor Green
+    Write-Host (" 9. Clear Cordova tmp files" + (Get-Est 'cordova')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
-    Write-Host (" 9. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
+    Write-Host ("10. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
-    Write-Host ("10. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
-    Write-Host ("11. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
-    Write-Host ("12. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
+    Write-Host ("11. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
+    Write-Host ("12. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
+    Write-Host ("13. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
     Write-Host ""
     Write-Host "99. Estimate reclaimable space (read-only, ~ = approximate)" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "→ Please enter your choice (0-12, or 99 to estimate): " -NoNewline
+    Write-Host "→ Please enter your choice (0-13, or 99 to estimate): " -NoNewline
 }
 
 # --- Main Loop ---
@@ -816,6 +840,7 @@ function Start-MainLoop {
                 Clear-NpmYarnPnpm
                 Clear-NuGet
                 Clear-PlatformIO
+                Clear-Cordova
                 Clear-IdeCaches
                 Clear-WindowsTemp
                 Clear-BrowserCaches
@@ -878,18 +903,22 @@ function Start-MainLoop {
                 Clear-PlatformIO
             }
             "9" {
+                Write-SectionHeader "Performing Cordova Cleanup"
+                Clear-Cordova
+            }
+            "10" {
                 Write-SectionHeader "Performing IDE Caches Cleanup"
                 Clear-IdeCaches
             }
-            "10" {
+            "11" {
                 Write-SectionHeader "Performing Windows Temp & Recycle Bin Cleanup"
                 Clear-WindowsTemp
             }
-            "11" {
+            "12" {
                 Write-SectionHeader "Performing Browser Caches Cleanup"
                 Clear-BrowserCaches
             }
-            "12" {
+            "13" {
                 Write-SectionHeader "Performing App Caches Cleanup"
                 Clear-AppContainers
             }
@@ -901,7 +930,7 @@ function Start-MainLoop {
                 continue
             }
             default {
-                Write-Host "Invalid choice. Please enter a number between 0 and 12." -ForegroundColor Red
+                Write-Host "Invalid choice. Please enter a number between 0 and 13." -ForegroundColor Red
                 Start-Sleep -Seconds 2
                 continue
             }

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -601,6 +601,16 @@ cleanup_timemachine_snapshots() {
     fi
 }
 
+cleanup_cordova() {
+    if [ -d "$HOME/.cordova" ]; then
+        print_item "✓" "${GREEN}" "Cleaning Cordova tmp files..."
+        # Cordova leaves stale npm tarballs/extractions under lib/tmp*
+        safe_rm -rf ~/.cordova/lib/tmp*
+    else
+        print_item "✕" "${YELLOW}" "Cordova not found. Skipping."
+    fi
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only feature: computes the current on-disk size of what every cleanup
 # option would remove, then display_menu() shows it next to each entry.
@@ -757,6 +767,11 @@ estimate_all() {
     set_estimate platformio "~$(human_kb "$pio_kb")"
     total=$((total + pio_kb))
 
+    print_item "•" "${FAINT}" "Measuring Cordova tmp files..."
+    kb=$(du_kb_sum "$HOME/.cordova/lib"/tmp*)
+    set_estimate cordova "$(human_kb "$kb")"
+    total=$((total + kb))
+
     print_item "•" "${FAINT}" "Measuring app container caches..."
     kb=$(du_kb_sum \
         "$HOME/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Caches"/* \
@@ -804,12 +819,13 @@ display_menu() {
     echo -e "${GREEN}10.${NC} Clear Browser Caches (Chrome, Brave, Firefox, Safari, Edge, Opera)$(est browser)"
     echo -e "${GREEN}11.${NC} Clear PlatformIO Caches$(est platformio)"
     echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)$(est android_sdk)"
-    echo -e "${GREEN}13.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
-    echo -e "${GREEN}14.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
+    echo -e "${GREEN}13.${NC} Clear Cordova tmp files$(est cordova)"
+    echo -e "${GREEN}14.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
+    echo -e "${GREEN}15.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo ""
     echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
     echo ""
-    echo -e "→ Please enter your choice (0-14, or 99 to estimate): ${NC}\c"
+    echo -e "→ Please enter your choice (0-15, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -882,6 +898,7 @@ main_loop() {
                 cleanup_ide_caches
                 cleanup_system_junk
                 cleanup_browser_caches
+                cleanup_cordova
                 cleanup_app_containers
                 cleanup_timemachine_snapshots
                 ;;
@@ -971,10 +988,14 @@ main_loop() {
                 cleanup_android_sdk
                 ;;
             13)
+                print_section_header "Performing Cordova Cleanup"
+                cleanup_cordova
+                ;;
+            14)
                 print_section_header "Performing App Containers Cleanup"
                 cleanup_app_containers
                 ;;
-            14)
+            15)
                 print_section_header "Performing Time Machine Snapshots Cleanup"
                 cleanup_timemachine_snapshots
                 ;;
@@ -986,7 +1007,7 @@ main_loop() {
                 continue
                 ;;
             *)
-                echo -e "${RED}Invalid choice. Please enter a number between 0 and 14.${NC}"
+                echo -e "${RED}Invalid choice. Please enter a number between 0 and 15.${NC}"
                 sleep 2
                 ;;
         esac


### PR DESCRIPTION
## What

Adds a Cordova cleanup routine that removes stale npm tarballs and extractions
that Cordova leaves under `~/.cordova/lib/tmp*`. These are disposable temp
artifacts (Cordova re-downloads them on the next build), so reclaiming them is
safe.

## Changes

- **`dev-cleaner.sh`**: new `cleanup_cordova` (guarded on `~/.cordova`), menu
  option **13**, estimator category, and wiring into "Clear All".
- **`dev-cleaner.ps1`**: parity — `Clear-Cordova`, menu option 9 (Development
  Tools group), estimator category, "Clear All" wiring.
- Renumbers a few trailing non-dev entries to keep the dev tools grouped
  (App Containers / Time Machine shift down by one). No behaviour change.

## Dry-run

Written to honour `--dry-run` from the start — deletions are routed through the
existing `safe_rm` helper (sh) / `Remove-SafelyWithTracking` (ps1), and the
estimator is read-only. Consistent with the convention enforced in #43.

Verified against the real script with a sandboxed `HOME`:

- `--dry-run` + option 13 → prints `[DRY-RUN] Would delete … tmp0/tmp1` and the
  files remain on disk.
- normal run + option 13 → the `tmp*` dirs are actually removed.

Rebased on top of current `main` (includes the #43 dry-run fix); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5fUUC7hVtnZYuyntNW5fa
