### PR TITLE
feat: add Electron cache cleanup routine

### DIFF
--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -609,6 +609,21 @@ function Clear-Cordova {
     }
 }
 
+function Clear-Electron {
+    $electronPath = "$env:LOCALAPPDATA\electron"
+
+    if (Test-Path $electronPath) {
+        Write-Item "✓" "Green" "Cleaning Electron cache..."
+        # Cached prebuilt binaries; wipe contents, keep the dir electron expects
+        $items = Get-ChildItem -Path $electronPath -Force -ErrorAction SilentlyContinue
+        foreach ($i in $items) {
+            Remove-SafelyWithTracking -Path $i.FullName -Description "Electron cache: $($i.Name)"
+        }
+    } else {
+        Write-Item "✕" "Yellow" "Electron not found. Skipping."
+    }
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only: computes the current on-disk size of what each cleanup option
 # would remove, then Show-Menu shows it next to each entry. Categories use
@@ -752,6 +767,14 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes $cordovaTmp
     Set-Estimate "cordova" (Format-Size $b); $total += $b
 
+    # Electron cache
+    Write-Host "  Measuring Electron cache..." -ForegroundColor DarkGray
+    $electronCache = @()
+    $electronItems = Get-ChildItem -Path "$env:LOCALAPPDATA\electron" -Force -ErrorAction SilentlyContinue
+    foreach ($e in $electronItems) { $electronCache += $e.FullName }
+    $b = Get-PathSizeBytes $electronCache
+    Set-Estimate "electron" (Format-Size $b); $total += $b
+
     # App containers
     Write-Host "  Measuring app caches..." -ForegroundColor DarkGray
     $acPaths = @(
@@ -804,16 +827,17 @@ function Show-Menu {
     Write-Host (" 7. Clear NuGet Package Cache" + (Get-Est 'nuget')) -ForegroundColor Green
     Write-Host (" 8. Clear PlatformIO Caches" + (Get-Est 'platformio')) -ForegroundColor Green
     Write-Host (" 9. Clear Cordova tmp files" + (Get-Est 'cordova')) -ForegroundColor Green
+    Write-Host ("10. Clear Electron cache" + (Get-Est 'electron')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
-    Write-Host ("10. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
+    Write-Host ("11. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
-    Write-Host ("11. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
-    Write-Host ("12. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
-    Write-Host ("13. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
+    Write-Host ("12. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
+    Write-Host ("13. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
+    Write-Host ("14. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
     Write-Host ""
     Write-Host "99. Estimate reclaimable space (read-only, ~ = approximate)" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "→ Please enter your choice (0-13, or 99 to estimate): " -NoNewline
+    Write-Host "→ Please enter your choice (0-14, or 99 to estimate): " -NoNewline
 }
 
 # --- Main Loop ---
@@ -841,6 +865,7 @@ function Start-MainLoop {
                 Clear-NuGet
                 Clear-PlatformIO
                 Clear-Cordova
+                Clear-Electron
                 Clear-IdeCaches
                 Clear-WindowsTemp
                 Clear-BrowserCaches
@@ -907,18 +932,22 @@ function Start-MainLoop {
                 Clear-Cordova
             }
             "10" {
+                Write-SectionHeader "Performing Electron Cleanup"
+                Clear-Electron
+            }
+            "11" {
                 Write-SectionHeader "Performing IDE Caches Cleanup"
                 Clear-IdeCaches
             }
-            "11" {
+            "12" {
                 Write-SectionHeader "Performing Windows Temp & Recycle Bin Cleanup"
                 Clear-WindowsTemp
             }
-            "12" {
+            "13" {
                 Write-SectionHeader "Performing Browser Caches Cleanup"
                 Clear-BrowserCaches
             }
-            "13" {
+            "14" {
                 Write-SectionHeader "Performing App Caches Cleanup"
                 Clear-AppContainers
             }
@@ -930,7 +959,7 @@ function Start-MainLoop {
                 continue
             }
             default {
-                Write-Host "Invalid choice. Please enter a number between 0 and 13." -ForegroundColor Red
+                Write-Host "Invalid choice. Please enter a number between 0 and 14." -ForegroundColor Red
                 Start-Sleep -Seconds 2
                 continue
             }

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -611,6 +611,16 @@ cleanup_cordova() {
     fi
 }
 
+cleanup_electron() {
+    if [ -d "$HOME/Library/Caches/electron" ]; then
+        print_item "✓" "${GREEN}" "Cleaning Electron cache..."
+        # Cached prebuilt binaries; wipe contents, keep the dir electron expects
+        safe_rm -rf ~/Library/Caches/electron/*
+    else
+        print_item "✕" "${YELLOW}" "Electron not found. Skipping."
+    fi
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only feature: computes the current on-disk size of what every cleanup
 # option would remove, then display_menu() shows it next to each entry.
@@ -772,6 +782,11 @@ estimate_all() {
     set_estimate cordova "$(human_kb "$kb")"
     total=$((total + kb))
 
+    print_item "•" "${FAINT}" "Measuring Electron cache..."
+    kb=$(du_kb_sum "$HOME/Library/Caches/electron"/*)
+    set_estimate electron "$(human_kb "$kb")"
+    total=$((total + kb))
+
     print_item "•" "${FAINT}" "Measuring app container caches..."
     kb=$(du_kb_sum \
         "$HOME/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Caches"/* \
@@ -820,12 +835,13 @@ display_menu() {
     echo -e "${GREEN}11.${NC} Clear PlatformIO Caches$(est platformio)"
     echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)$(est android_sdk)"
     echo -e "${GREEN}13.${NC} Clear Cordova tmp files$(est cordova)"
-    echo -e "${GREEN}14.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
-    echo -e "${GREEN}15.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
+    echo -e "${GREEN}14.${NC} Clear Electron cache$(est electron)"
+    echo -e "${GREEN}15.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
+    echo -e "${GREEN}16.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo ""
     echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
     echo ""
-    echo -e "→ Please enter your choice (0-15, or 99 to estimate): ${NC}\c"
+    echo -e "→ Please enter your choice (0-16, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -899,6 +915,7 @@ main_loop() {
                 cleanup_system_junk
                 cleanup_browser_caches
                 cleanup_cordova
+                cleanup_electron
                 cleanup_app_containers
                 cleanup_timemachine_snapshots
                 ;;
@@ -992,10 +1009,14 @@ main_loop() {
                 cleanup_cordova
                 ;;
             14)
+                print_section_header "Performing Electron Cleanup"
+                cleanup_electron
+                ;;
+            15)
                 print_section_header "Performing App Containers Cleanup"
                 cleanup_app_containers
                 ;;
-            15)
+            16)
                 print_section_header "Performing Time Machine Snapshots Cleanup"
                 cleanup_timemachine_snapshots
                 ;;
@@ -1007,7 +1028,7 @@ main_loop() {
                 continue
                 ;;
             *)
-                echo -e "${RED}Invalid choice. Please enter a number between 0 and 15.${NC}"
+                echo -e "${RED}Invalid choice. Please enter a number between 0 and 16.${NC}"
                 sleep 2
                 ;;
         esac


### PR DESCRIPTION
## What

Adds an Electron cleanup routine that wipes the cached prebuilt Electron
binaries under `~/Library/Caches/electron` (Windows: `%LOCALAPPDATA%\electron`).
It clears the *contents* but keeps the `electron` directory itself, since
Electron recreates the contents on the next download but expects the dir to
exist. These are re-downloadable artifacts, so reclaiming them is safe.

## Changes

- **`dev-cleaner.sh`**: new `cleanup_electron` (guarded on
  `~/Library/Caches/electron`, routed through `safe_rm` so it honours
  `--dry-run`), menu option **14**, estimator category, and "Clear All" wiring.
- **`dev-cleaner.ps1`**: parity — `Clear-Electron`
  (`$env:LOCALAPPDATA\electron`), menu option 10 (Development Tools group),
  estimator category, "Clear All" wiring.
- Renumbers a few trailing non-dev entries to keep the dev tools grouped
  (App Containers / Time Machine shift down by one). No behaviour change.

## Dry-run

`--dry-run` is a `.sh` feature; the routine routes its deletion through the
existing `safe_rm` helper, so dry-run previews the removal instead of doing it.
The estimator is read-only. (The PowerShell port has no dry-run mode — same as
all its other routines — so `Clear-Electron` matches that existing behaviour.)

Verified against the real script with a sandboxed `HOME`:

- `--dry-run` + option 14 → prints `[DRY-RUN] Would delete …` for the cached
  files and they remain on disk.
- normal run + option 14 → the cache contents are removed and the `electron`
  directory itself is preserved.

Rebased on top of current `main` (includes the Cordova routine from #46); no
conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5fUUC7hVtnZYuyntNW5fa
