### PR TITLE
feat: add Docker cleanup routine (prune -f, opt-in -af)

### DIFF
--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -624,6 +624,25 @@ function Clear-Electron {
     }
 }
 
+function Clear-Docker {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Item "✕" "Yellow" "Docker not found. Skipping."
+        return
+    }
+    # `Get-Command` only proves the CLI exists; the daemon may still be down.
+    $dfOut = docker system df 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $dfOut) {
+        Write-Item "✕" "Yellow" "Docker daemon not running. Skipping."
+        return
+    }
+    Write-Item "✓" "Green" "Docker disk usage:"
+    $dfOut | ForEach-Object { Write-Host $_ }
+    # -f skips docker's own confirmation (the script already confirmed).
+    # --volumes is intentionally omitted: it would delete named-volume data
+    # (e.g. databases), which is out of scope for a cache cleaner.
+    docker system prune -f
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only: computes the current on-disk size of what each cleanup option
 # would remove, then Show-Menu shows it next to each entry. Categories use
@@ -775,6 +794,25 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes $electronCache
     Set-Estimate "electron" (Format-Size $b); $total += $b
 
+    # Docker is not path-based: ask docker itself (read-only `system df`).
+    # docker-reported reclaimable for images + build cache (what `prune -f`
+    # targets, volumes excluded); approximate, so not added to the byte total.
+    Write-Host "  Measuring Docker reclaimable space..." -ForegroundColor DarkGray
+    if (Get-Command docker -ErrorAction SilentlyContinue) {
+        $dfFmt = docker system df --format '{{.Type}}|{{.Reclaimable}}' 2>$null
+        if ($LASTEXITCODE -eq 0 -and $dfFmt) {
+            $imgR = (($dfFmt | Where-Object { $_ -like 'Images|*' }) -split '\|', 2)[1] -replace ' *\(.*', ''
+            $cacheR = (($dfFmt | Where-Object { $_ -like 'Build Cache|*' }) -split '\|', 2)[1] -replace ' *\(.*', ''
+            if (-not $imgR) { $imgR = '0B' }
+            if (-not $cacheR) { $cacheR = '0B' }
+            Set-Estimate "docker" "~$imgR img + $cacheR cache"
+        } else {
+            Set-Estimate "docker" "n/a (daemon not running)"
+        }
+    } else {
+        Set-Estimate "docker" "n/a (docker not found)"
+    }
+
     # App containers
     Write-Host "  Measuring app caches..." -ForegroundColor DarkGray
     $acPaths = @(
@@ -828,16 +866,17 @@ function Show-Menu {
     Write-Host (" 8. Clear PlatformIO Caches" + (Get-Est 'platformio')) -ForegroundColor Green
     Write-Host (" 9. Clear Cordova tmp files" + (Get-Est 'cordova')) -ForegroundColor Green
     Write-Host ("10. Clear Electron cache" + (Get-Est 'electron')) -ForegroundColor Green
+    Write-Host ("11. Clear Docker (prune: stopped containers, dangling images, build cache)" + (Get-Est 'docker')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
-    Write-Host ("11. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
+    Write-Host ("12. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
-    Write-Host ("12. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
-    Write-Host ("13. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
-    Write-Host ("14. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
+    Write-Host ("13. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
+    Write-Host ("14. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
+    Write-Host ("15. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
     Write-Host ""
     Write-Host "99. Estimate reclaimable space (read-only, ~ = approximate)" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "→ Please enter your choice (0-14, or 99 to estimate): " -NoNewline
+    Write-Host "→ Please enter your choice (0-15, or 99 to estimate): " -NoNewline
 }
 
 # --- Main Loop ---
@@ -866,6 +905,7 @@ function Start-MainLoop {
                 Clear-PlatformIO
                 Clear-Cordova
                 Clear-Electron
+                Clear-Docker
                 Clear-IdeCaches
                 Clear-WindowsTemp
                 Clear-BrowserCaches
@@ -936,18 +976,22 @@ function Start-MainLoop {
                 Clear-Electron
             }
             "11" {
+                Write-SectionHeader "Performing Docker Cleanup"
+                Clear-Docker
+            }
+            "12" {
                 Write-SectionHeader "Performing IDE Caches Cleanup"
                 Clear-IdeCaches
             }
-            "12" {
+            "13" {
                 Write-SectionHeader "Performing Windows Temp & Recycle Bin Cleanup"
                 Clear-WindowsTemp
             }
-            "13" {
+            "14" {
                 Write-SectionHeader "Performing Browser Caches Cleanup"
                 Clear-BrowserCaches
             }
-            "14" {
+            "15" {
                 Write-SectionHeader "Performing App Caches Cleanup"
                 Clear-AppContainers
             }
@@ -959,7 +1003,7 @@ function Start-MainLoop {
                 continue
             }
             default {
-                Write-Host "Invalid choice. Please enter a number between 0 and 14." -ForegroundColor Red
+                Write-Host "Invalid choice. Please enter a number between 0 and 15." -ForegroundColor Red
                 Start-Sleep -Seconds 2
                 continue
             }

--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -104,6 +104,27 @@ function Format-Size {
     else                    { return ("{0} B" -f $Bytes) }
 }
 
+# Convert a Docker size string (Docker uses DECIMAL units: B/kB/MB/GB/TB,
+# e.g. "1.02GB", "728.5MB", "32.8kB", "0B") into bytes, so Docker's own
+# self-reported sizes can be summed and fed to Format-Size like every other
+# estimate. Suffix order matters: kB/MB/GB/TB all end in "B", so the bare
+# "B" case must be checked last. Docker always prints a dot as the decimal
+# separator, hence InvariantCulture. Read-only.
+function Convert-DockerSize {
+    param([string]$Size)
+    if ([string]::IsNullOrWhiteSpace($Size)) { return [int64]0 }
+    $s = $Size.Trim()
+    $ci = [System.Globalization.CultureInfo]::InvariantCulture
+    try {
+        if     ($s -match '^([\d.]+)TB$') { return [int64]([double]::Parse($Matches[1], $ci) * 1e12) }
+        elseif ($s -match '^([\d.]+)GB$') { return [int64]([double]::Parse($Matches[1], $ci) * 1e9) }
+        elseif ($s -match '^([\d.]+)MB$') { return [int64]([double]::Parse($Matches[1], $ci) * 1e6) }
+        elseif ($s -match '^([\d.]+)kB$') { return [int64]([double]::Parse($Matches[1], $ci) * 1e3) }
+        elseif ($s -match '^([\d.]+)B$')  { return [int64][double]::Parse($Matches[1], $ci) }
+    } catch { }
+    return [int64]0
+}
+
 function Set-Estimate {
     param([string]$Key, [string]$Label)
     $script:Estimates[$Key] = $Label
@@ -624,7 +645,11 @@ function Clear-Electron {
     }
 }
 
+# -Interactive offers the deeper `prune -af` via a secondary prompt. "Clear All
+# Caches" calls this without it, so a bulk run never deletes tagged images by
+# surprise.
 function Clear-Docker {
+    param([switch]$Interactive)
     if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
         Write-Item "✕" "Yellow" "Docker not found. Skipping."
         return
@@ -637,10 +662,23 @@ function Clear-Docker {
     }
     Write-Item "✓" "Green" "Docker disk usage:"
     $dfOut | ForEach-Object { Write-Host $_ }
-    # -f skips docker's own confirmation (the script already confirmed).
-    # --volumes is intentionally omitted: it would delete named-volume data
-    # (e.g. databases), which is out of scope for a cache cleaner.
-    docker system prune -f
+
+    # `prune -f` removes stopped containers, unused networks, dangling
+    # (untagged) images and unused build cache; -f skips docker's own
+    # confirmation (the script already confirmed). `-a` additionally removes
+    # EVERY image not used by a container, including tagged ones that may only
+    # exist in a private registry — so it's opt-in via a prompt, never in the
+    # bulk "Clear All" path. (--volumes stays omitted in both: it would delete
+    # named-volume data like databases.)
+    $pruneArgs = @('-f')
+    if ($Interactive) {
+        Write-Host ""
+        Write-Host "Also remove unused but TAGGED images? Frees more space, but they" -ForegroundColor Yellow
+        Write-Host "must be re-pulled/rebuilt (e.g. private-registry images). (y/N):" -ForegroundColor Yellow
+        $ans = Read-Host
+        if ($ans -eq 'y') { $pruneArgs = @('-af') }
+    }
+    docker system prune @pruneArgs
 }
 
 # --- Reclaimable-space estimation ---
@@ -794,18 +832,45 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes $electronCache
     Set-Estimate "electron" (Format-Size $b); $total += $b
 
-    # Docker is not path-based: ask docker itself (read-only `system df`).
-    # docker-reported reclaimable for images + build cache (what `prune -f`
-    # targets, volumes excluded); approximate, so not added to the byte total.
+    # Docker is not path-based: ask docker itself (read-only). Two figures,
+    # because option 11 offers two prune modes:
+    #   -f  : build-cache reclaimable + dangling (untagged) images
+    #   -af : the above + ALL images not used by a container (tagged too)
+    # Build-cache reclaimable comes from the `system df` summary (Docker
+    # computes it correctly; only its Images figure is unreliable with the
+    # containerd image store). Per-image sizes come from `system df -v`,
+    # summing UNIQUE SIZE of 0-container rows so shared layers aren't double
+    # counted. Approximate, so not added to the byte total.
     Write-Host "  Measuring Docker reclaimable space..." -ForegroundColor DarkGray
     if (Get-Command docker -ErrorAction SilentlyContinue) {
         $dfFmt = docker system df --format '{{.Type}}|{{.Reclaimable}}' 2>$null
         if ($LASTEXITCODE -eq 0 -and $dfFmt) {
-            $imgR = (($dfFmt | Where-Object { $_ -like 'Images|*' }) -split '\|', 2)[1] -replace ' *\(.*', ''
-            $cacheR = (($dfFmt | Where-Object { $_ -like 'Build Cache|*' }) -split '\|', 2)[1] -replace ' *\(.*', ''
-            if (-not $imgR) { $imgR = '0B' }
-            if (-not $cacheR) { $cacheR = '0B' }
-            Set-Estimate "docker" "~$imgR img + $cacheR cache"
+            $cacheTok = (($dfFmt | Where-Object { $_ -like 'Build Cache|*' }) -split '\|', 2)[1] -replace ' *\(.*', ''
+            [int64]$cacheBytes = Convert-DockerSize $cacheTok
+            # Parse the "Images space usage:" table. CREATED is multi-word
+            # ("4 days ago"), so index columns from the RIGHT: last = CONTAINERS,
+            # second-to-last = UNIQUE SIZE. Dangling images have REPOSITORY <none>.
+            [int64]$danglingBytes = 0
+            [int64]$allUnusedBytes = 0
+            $inImages = $false
+            foreach ($line in (docker system df -v 2>$null)) {
+                if ($line -match '^Images space usage:') { $inImages = $true; continue }
+                if (-not $inImages) { continue }
+                if ($line -match '^REPOSITORY') { continue }
+                if ([string]::IsNullOrWhiteSpace($line)) { $inImages = $false; continue }
+                $cols = $line.Trim() -split '\s+'
+                if ($cols.Count -lt 3 -or $cols[-1] -ne '0') { continue }
+                $uniq = Convert-DockerSize $cols[-2]
+                $allUnusedBytes += $uniq
+                if ($cols[0] -eq '<none>') { $danglingBytes += $uniq }
+            }
+            [int64]$fBytes = $cacheBytes + $danglingBytes
+            [int64]$afBytes = $cacheBytes + $allUnusedBytes
+            if ($afBytes -gt $fBytes) {
+                Set-Estimate "docker" "~$(Format-Size $fBytes) → ~$(Format-Size $afBytes) with -a"
+            } else {
+                Set-Estimate "docker" "~$(Format-Size $fBytes)"
+            }
         } else {
             Set-Estimate "docker" "n/a (daemon not running)"
         }
@@ -866,7 +931,7 @@ function Show-Menu {
     Write-Host (" 8. Clear PlatformIO Caches" + (Get-Est 'platformio')) -ForegroundColor Green
     Write-Host (" 9. Clear Cordova tmp files" + (Get-Est 'cordova')) -ForegroundColor Green
     Write-Host ("10. Clear Electron cache" + (Get-Est 'electron')) -ForegroundColor Green
-    Write-Host ("11. Clear Docker (prune: stopped containers, dangling images, build cache)" + (Get-Est 'docker')) -ForegroundColor Green
+    Write-Host ("11. Clear Docker (prune containers, dangling images & build cache; asks before removing unused tagged images)" + (Get-Est 'docker')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
     Write-Host ("12. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
@@ -977,7 +1042,7 @@ function Start-MainLoop {
             }
             "11" {
                 Write-SectionHeader "Performing Docker Cleanup"
-                Clear-Docker
+                Clear-Docker -Interactive
             }
             "12" {
                 Write-SectionHeader "Performing IDE Caches Cleanup"

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -100,6 +100,22 @@ human_kb() {
     }'
 }
 
+# Convert a Docker size string (Docker uses DECIMAL units: B/kB/MB/GB/TB,
+# e.g. "1.02GB", "728.5MB", "32.8kB", "0B") into KiB so Docker's own
+# self-reported sizes can be summed and fed to human_kb() like every other
+# estimate. Suffix order matters: kB/MB/GB/TB all end in "B", so the bare
+# "B" case must be checked last. Read-only.
+docker_size_to_kb() {
+    awk -v s="${1:-0B}" 'BEGIN {
+        if      (s ~ /TB$/) { sub(/TB$/,"",s); printf "%d", s*1e12/1024 }
+        else if (s ~ /GB$/) { sub(/GB$/,"",s); printf "%d", s*1e9/1024 }
+        else if (s ~ /MB$/) { sub(/MB$/,"",s); printf "%d", s*1e6/1024 }
+        else if (s ~ /kB$/) { sub(/kB$/,"",s); printf "%d", s*1e3/1024 }
+        else if (s ~  /B$/) { sub(/B$/,"",s);  printf "%d", s/1024 }
+        else                { printf "0" }
+    }'
+}
+
 # Sum the disk usage (in KB) of the given paths/globs. Read-only.
 # Glob handling mirrors safe_rm() so the estimate matches what cleanup deletes.
 # Usage: du_kb_sum <path-or-glob> [<path-or-glob> ...]
@@ -621,7 +637,12 @@ cleanup_electron() {
     fi
 }
 
+# Usage: cleanup_docker [interactive]
+#   no arg      -> safe `prune -f` only, no prompt (used by "Clear All Caches"
+#                  so a bulk run never deletes tagged images by surprise)
+#   interactive -> offer the deeper `prune -af` via a secondary prompt
 cleanup_docker() {
+    local mode="${1:-}"
     if ! command -v docker &> /dev/null; then
         print_item "✕" "${YELLOW}" "Docker not found. Skipping."
         return
@@ -634,16 +655,34 @@ cleanup_docker() {
     fi
     print_item "✓" "${GREEN}" "Docker disk usage:"
     echo "$df_out"
+
+    # `prune -f` removes stopped containers, unused networks, dangling
+    # (untagged) images and unused build cache. `-a` additionally removes
+    # EVERY image not used by a container, including tagged ones that may
+    # only exist in a private registry — so it's opt-in via a prompt, never
+    # in the bulk "Clear All" path. (--volumes stays omitted in both: it
+    # would delete named-volume data like databases.)
+    local prune_args="-f"
+    if [ "$mode" = "interactive" ] && ! $DRY_RUN; then
+        echo ""
+        echo -e "${YELLOW}Also remove unused but TAGGED images? Frees more space, but they"
+        echo -e "must be re-pulled/rebuilt (e.g. private-registry images). (y/N):${NC}"
+        local ans
+        read -r ans
+        if [[ "$ans" == "y" || "$ans" == "Y" ]]; then
+            prune_args="-af"
+        fi
+    fi
+
     # Docker has no real --dry-run, so honour the flag manually like
-    # cleanup_android_sdk: prune is destructive (but rebuildable from
-    # Dockerfiles), so just announce it under --dry-run instead of running.
+    # cleanup_android_sdk: prune is destructive (but rebuildable), so just
+    # announce it under --dry-run instead of running. -f skips docker's own
+    # confirmation (the script already confirmed).
     if $DRY_RUN; then
         echo -e "${YELLOW}[DRY-RUN] Would run: docker system prune -f${NC}"
+        echo -e "${FAINT}  (option 15 also offers 'docker system prune -af' to remove unused tagged images)${NC}"
     else
-        # -f skips docker's own confirmation (the script already confirmed).
-        # --volumes is intentionally omitted: it would delete named-volume
-        # data (e.g. databases), which is out of scope for a cache cleaner.
-        docker system prune -f
+        docker system prune $prune_args
     fi
 }
 
@@ -813,18 +852,50 @@ estimate_all() {
     set_estimate electron "$(human_kb "$kb")"
     total=$((total + kb))
 
-    # Docker is not path-based: ask docker itself (read-only `system df`).
-    # docker-reported reclaimable for images + build cache (what `prune -f`
-    # targets, volumes excluded); approximate, so not added to the byte total.
+    # Docker is not path-based: ask docker itself (read-only). Two figures,
+    # because option 15 offers two prune modes:
+    #   -f  : build-cache reclaimable + dangling (untagged) images
+    #   -af : the above + ALL images not used by a container (tagged too)
+    # Build-cache reclaimable comes from the `system df` summary (Docker
+    # computes it correctly; only its Images figure is unreliable with the
+    # containerd image store). Per-image sizes come from `system df -v`,
+    # summing UNIQUE SIZE of 0-container rows so shared layers aren't double
+    # counted. Approximate, so not added to the byte total.
     print_item "•" "${FAINT}" "Measuring Docker reclaimable space..."
     local df_fmt
     if command -v docker &> /dev/null \
         && df_fmt=$(docker system df --format '{{.Type}}|{{.Reclaimable}}' 2>/dev/null) \
         && [ -n "$df_fmt" ]; then
-        local img_r cache_r
-        img_r=$(echo "$df_fmt" | awk -F'|' '$1=="Images"{sub(/ *\(.*/,"",$2);print $2}')
-        cache_r=$(echo "$df_fmt" | awk -F'|' '$1=="Build Cache"{sub(/ *\(.*/,"",$2);print $2}')
-        set_estimate docker "~${img_r:-0B} img + ${cache_r:-0B} cache"
+        local cache_tok cache_kb dangling_kb allunused_kb f_kb af_kb
+        cache_tok=$(echo "$df_fmt" | awk -F'|' '$1=="Build Cache"{sub(/ *\(.*/,"",$2);print $2}')
+        cache_kb=$(docker_size_to_kb "${cache_tok:-0B}")
+        # Parse the "Images space usage:" table. CREATED is multi-word
+        # ("4 days ago"), so index fields from the RIGHT: $NF=CONTAINERS,
+        # $(NF-1)=UNIQUE SIZE. d=dangling 0-container, a=all 0-container.
+        read -r dangling_kb allunused_kb < <(docker system df -v 2>/dev/null | awk '
+            function tokb(s) {
+                if      (s ~ /TB$/) { sub(/TB$/,"",s); return s*1e12/1024 }
+                else if (s ~ /GB$/) { sub(/GB$/,"",s); return s*1e9/1024 }
+                else if (s ~ /MB$/) { sub(/MB$/,"",s); return s*1e6/1024 }
+                else if (s ~ /kB$/) { sub(/kB$/,"",s); return s*1e3/1024 }
+                else if (s ~  /B$/) { sub(/B$/,"",s);  return s/1024 }
+                return 0
+            }
+            /^Images space usage:/ { in_img=1; next }
+            in_img && /^REPOSITORY/ { hdr=1; next }
+            in_img && hdr {
+                if (NF==0) { in_img=0; hdr=0; next }
+                if ($NF==0) { a += tokb($(NF-1)); if ($1=="<none>") d += tokb($(NF-1)) }
+                next
+            }
+            END { printf "%d %d\n", d+0, a+0 }')
+        f_kb=$(( cache_kb + ${dangling_kb:-0} ))
+        af_kb=$(( cache_kb + ${allunused_kb:-0} ))
+        if [ "$af_kb" -gt "$f_kb" ]; then
+            set_estimate docker "~$(human_kb "$f_kb") → ~$(human_kb "$af_kb") with -a"
+        else
+            set_estimate docker "~$(human_kb "$f_kb")"
+        fi
     elif command -v docker &> /dev/null; then
         set_estimate docker "n/a (daemon not running)"
     else
@@ -880,7 +951,7 @@ display_menu() {
     echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)$(est android_sdk)"
     echo -e "${GREEN}13.${NC} Clear Cordova tmp files$(est cordova)"
     echo -e "${GREEN}14.${NC} Clear Electron cache$(est electron)"
-    echo -e "${GREEN}15.${NC} Clear Docker (prune: stopped containers, dangling images, build cache)$(est docker)"
+    echo -e "${GREEN}15.${NC} Clear Docker (prune containers, dangling images & build cache; asks before removing unused tagged images)$(est docker)"
     echo -e "${GREEN}16.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
     echo -e "${GREEN}17.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo ""
@@ -1060,7 +1131,7 @@ main_loop() {
                 ;;
             15)
                 print_section_header "Performing Docker Cleanup"
-                cleanup_docker
+                cleanup_docker interactive
                 ;;
             16)
                 print_section_header "Performing App Containers Cleanup"

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -621,6 +621,32 @@ cleanup_electron() {
     fi
 }
 
+cleanup_docker() {
+    if ! command -v docker &> /dev/null; then
+        print_item "✕" "${YELLOW}" "Docker not found. Skipping."
+        return
+    fi
+    # `command -v` only proves the CLI exists; the daemon may still be down.
+    local df_out
+    if ! df_out=$(docker system df 2>/dev/null); then
+        print_item "✕" "${YELLOW}" "Docker daemon not running. Skipping."
+        return
+    fi
+    print_item "✓" "${GREEN}" "Docker disk usage:"
+    echo "$df_out"
+    # Docker has no real --dry-run, so honour the flag manually like
+    # cleanup_android_sdk: prune is destructive (but rebuildable from
+    # Dockerfiles), so just announce it under --dry-run instead of running.
+    if $DRY_RUN; then
+        echo -e "${YELLOW}[DRY-RUN] Would run: docker system prune -f${NC}"
+    else
+        # -f skips docker's own confirmation (the script already confirmed).
+        # --volumes is intentionally omitted: it would delete named-volume
+        # data (e.g. databases), which is out of scope for a cache cleaner.
+        docker system prune -f
+    fi
+}
+
 # --- Reclaimable-space estimation ---
 # Read-only feature: computes the current on-disk size of what every cleanup
 # option would remove, then display_menu() shows it next to each entry.
@@ -787,6 +813,24 @@ estimate_all() {
     set_estimate electron "$(human_kb "$kb")"
     total=$((total + kb))
 
+    # Docker is not path-based: ask docker itself (read-only `system df`).
+    # docker-reported reclaimable for images + build cache (what `prune -f`
+    # targets, volumes excluded); approximate, so not added to the byte total.
+    print_item "•" "${FAINT}" "Measuring Docker reclaimable space..."
+    local df_fmt
+    if command -v docker &> /dev/null \
+        && df_fmt=$(docker system df --format '{{.Type}}|{{.Reclaimable}}' 2>/dev/null) \
+        && [ -n "$df_fmt" ]; then
+        local img_r cache_r
+        img_r=$(echo "$df_fmt" | awk -F'|' '$1=="Images"{sub(/ *\(.*/,"",$2);print $2}')
+        cache_r=$(echo "$df_fmt" | awk -F'|' '$1=="Build Cache"{sub(/ *\(.*/,"",$2);print $2}')
+        set_estimate docker "~${img_r:-0B} img + ${cache_r:-0B} cache"
+    elif command -v docker &> /dev/null; then
+        set_estimate docker "n/a (daemon not running)"
+    else
+        set_estimate docker "n/a (docker not found)"
+    fi
+
     print_item "•" "${FAINT}" "Measuring app container caches..."
     kb=$(du_kb_sum \
         "$HOME/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Caches"/* \
@@ -836,12 +880,13 @@ display_menu() {
     echo -e "${GREEN}12.${NC} Clean Android SDK (old build-tools, x86 images)$(est android_sdk)"
     echo -e "${GREEN}13.${NC} Clear Cordova tmp files$(est cordova)"
     echo -e "${GREEN}14.${NC} Clear Electron cache$(est electron)"
-    echo -e "${GREEN}15.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
-    echo -e "${GREEN}16.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
+    echo -e "${GREEN}15.${NC} Clear Docker (prune: stopped containers, dangling images, build cache)$(est docker)"
+    echo -e "${GREEN}16.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
+    echo -e "${GREEN}17.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo ""
     echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
     echo ""
-    echo -e "→ Please enter your choice (0-16, or 99 to estimate): ${NC}\c"
+    echo -e "→ Please enter your choice (0-17, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -916,6 +961,7 @@ main_loop() {
                 cleanup_browser_caches
                 cleanup_cordova
                 cleanup_electron
+                cleanup_docker
                 cleanup_app_containers
                 cleanup_timemachine_snapshots
                 ;;
@@ -1013,10 +1059,14 @@ main_loop() {
                 cleanup_electron
                 ;;
             15)
+                print_section_header "Performing Docker Cleanup"
+                cleanup_docker
+                ;;
+            16)
                 print_section_header "Performing App Containers Cleanup"
                 cleanup_app_containers
                 ;;
-            16)
+            17)
                 print_section_header "Performing Time Machine Snapshots Cleanup"
                 cleanup_timemachine_snapshots
                 ;;
@@ -1028,7 +1078,7 @@ main_loop() {
                 continue
                 ;;
             *)
-                echo -e "${RED}Invalid choice. Please enter a number between 0 and 16.${NC}"
+                echo -e "${RED}Invalid choice. Please enter a number between 0 and 17.${NC}"
                 sleep 2
                 ;;
         esac


### PR DESCRIPTION
## What

Adds a Docker cleanup routine. After showing `docker system df`, it runs
`docker system prune -f` — reclaiming stopped containers, unused networks,
dangling (untagged) images and unused build cache. Everything removed is
rebuildable from Dockerfiles / re-pullable.

Two deliberate safety boundaries:

- **`--volumes` is never passed** (neither in the `-f` nor the `-af` path), so
  named-volume data such as databases is never touched — out of scope for a
  cache cleaner.
- **Removing unused *tagged* images (`-af`) is opt-in.** Menu option 15 asks
  before adding `-a`; the bulk "Clear All" path stays on the safe `-f` only, so
  a mass run never deletes tagged images (e.g. private-registry ones) by
  surprise.

A two-level guard keeps it robust: `command -v docker` proves the CLI exists,
then a `docker system df` probe confirms the daemon is up — a present CLI with a
stopped daemon degrades to a clean "Docker daemon not running. Skipping."
instead of a raw API error.

## Changes

- **`dev-cleaner.sh`**: new `cleanup_docker` (menu option **15**), estimator
  category, and "Clear All" wiring (safe `-f` only).
- **`dev-cleaner.ps1`**: parity — `Clear-Docker`, menu option 11 (Development
  Tools group), estimator category, "Clear All" wiring.
- Estimator: read-only `docker system df -v`, summing the unique size of
  0-container image rows (dangling for `-f`, all unused for `-af`), shown as
  "~X → ~Y with -a". Reclaimable volumes are excluded and the figure is not
  added to the byte total — same precedent as the Time Machine snapshot count.
- Renumbers a few trailing non-dev entries to keep the dev tools grouped
  (App Containers / Time Machine shift down by one). No behaviour change.

## Dry-run

Docker has no real `--dry-run`, so the routine honours the flag **manually**
(like `cleanup_android_sdk`): under `--dry-run` it announces
`docker system prune -f` instead of running it, and the interactive `-af` prompt
is skipped. The estimator is read-only. (The PowerShell port has no dry-run
mode — same as all its other routines.)

Verified against the real script with a fake `docker` shim that logs every
invocation:

- `--dry-run` + option 15 → prints `[DRY-RUN] Would run: docker system prune -f`
  and the shim log shows **only** the read-only `system df` probe — `prune` is
  never executed.
- CLI-missing and daemon-down cases → clean "Skipping." messages, no prune.

(The real prune path was intentionally not executed in testing, since it mutates
real Docker state.)

Rebased on top of current `main` (includes the Cordova #46 and Electron #47
routines); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5fUUC7hVtnZYuyntNW5fa
