### PR TITLE
feat: clean Gradle wrapper and legacy ~/.android caches

### DIFF
--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -257,8 +257,17 @@ function Clear-AndroidGradle {
         Write-Item "✓" "Green" "Cleaning Gradle caches..."
         Remove-SafelyWithTracking -Path "$env:USERPROFILE\.gradle\caches" -Description "Gradle caches"
         Remove-SafelyWithTracking -Path "$env:USERPROFILE\.gradle\daemon" -Description "Gradle daemon"
+        # Downloaded Gradle distributions; re-fetched on next wrapper run.
+        Remove-SafelyWithTracking -Path "$env:USERPROFILE\.gradle\wrapper" -Description "Gradle wrapper distributions"
     } else {
         Write-Item "✕" "Yellow" "Gradle directory not found. Skipping."
+    }
+
+    if (Test-Path "$env:USERPROFILE\.android") {
+        Write-Item "✓" "Green" "Cleaning Android tool caches..."
+        # Legacy AVD/build caches under ~/.android; regenerated on demand.
+        Remove-SafelyWithTracking -Path "$env:USERPROFILE\.android\cache" -Description "Android cache"
+        Remove-SafelyWithTracking -Path "$env:USERPROFILE\.android\build-cache" -Description "Android build-cache"
     }
 
     Write-Item "✓" "Green" "Cleaning Android Studio caches..."
@@ -710,6 +719,9 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes @(
         "$env:USERPROFILE\.gradle\caches",
         "$env:USERPROFILE\.gradle\daemon",
+        "$env:USERPROFILE\.gradle\wrapper",
+        "$env:USERPROFILE\.android\cache",
+        "$env:USERPROFILE\.android\build-cache",
         "$env:LOCALAPPDATA\Google\AndroidStudio*",
         "$env:LOCALAPPDATA\JetBrains\AndroidStudio*"
     )

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -305,8 +305,16 @@ cleanup_android() {
         print_item "✓" "${GREEN}" "Cleaning Gradle caches..."
         safe_rm -rf ~/.gradle/caches/
         safe_rm -rf ~/.gradle/daemon/
+        # Downloaded Gradle distributions; re-fetched on next wrapper run.
+        safe_rm -rf ~/.gradle/wrapper/
     else
         print_item "✕" "${YELLOW}" "Gradle directory not found. Skipping."
+    fi
+    if [ -d "$HOME/.android" ]; then
+        print_item "✓" "${GREEN}" "Cleaning Android tool caches..."
+        # Legacy AVD/build caches under ~/.android; regenerated on demand.
+        safe_rm -rf ~/.android/cache/
+        safe_rm -rf ~/.android/build-cache/
     fi
     print_item "✓" "${GREEN}" "Cleaning Android Studio caches..."
     safe_rm -rf ~/Library/Caches/Google/AndroidStudio*
@@ -733,6 +741,9 @@ estimate_all() {
     kb=$(du_kb_sum \
         "$HOME/.gradle/caches" \
         "$HOME/.gradle/daemon" \
+        "$HOME/.gradle/wrapper" \
+        "$HOME/.android/cache" \
+        "$HOME/.android/build-cache" \
         "$HOME/Library/Caches/Google"/AndroidStudio* \
         "$HOME/Library/Caches/JetBrains"/AndroidStudio*)
     set_estimate android "$(human_kb "$kb")"


### PR DESCRIPTION
## Summary
Extends the Android cleanup routine to remove three cache locations that the standalone `clean-android-studio.sh` covered but `dev-cleaner` did not:

- `~/.gradle/wrapper/` — downloaded Gradle distributions (re-fetched on next wrapper run)
- `~/.android/cache/` and `~/.android/build-cache/` — legacy AVD/build caches, regenerated on demand

The same paths are added to the `android` space estimate so the menu figure stays accurate. Applied to **both** `dev-cleaner.sh` and the Windows `dev-cleaner.ps1`.

## Notes
- Uses the existing `safe_rm` / `Remove-SafelyWithTracking` primitives, so `--dry-run`, freed-space tracking, and missing-path handling work automatically.
- `~/.gradle/wrapper` sits inside the existing `~/.gradle` guard; `~/.android/*` gets its own directory check.

## Testing
- `bash -n` and `shellcheck -S error` pass clean on `dev-cleaner.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRbtQmJp9cvV4hmNBp9jNn