### PR TITLE
feat: clean CoreSimulator caches in Xcode cleanup

### DIFF
--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -286,6 +286,13 @@ cleanup_xcode() {
     safe_rm -rf ~/Library/Developer/Xcode/DerivedData/
     print_item "✓" "${GREEN}" "Removing old Simulator devices..."
     safe_rm -rf ~/Library/Developer/CoreSimulator/Devices/
+    print_item "✓" "${GREEN}" "Removing CoreSimulator caches..."
+    safe_rm -rf ~/Library/Developer/CoreSimulator/Caches/*
+    # System-level CoreSimulator cache lives under /Library and needs sudo.
+    # Close Xcode/Simulator first so we don't clear files still in use.
+    print_item "ℹ️" "${YELLOW}" "Make sure Xcode and Simulator are closed before clearing the system CoreSimulator cache."
+    print_item "✓" "${GREEN}" "Removing system CoreSimulator caches (sudo)..."
+    safe_sudo_rm -rf /Library/Developer/CoreSimulator/Caches/*
     print_item "✓" "${GREEN}" "Removing old device support files..."
     safe_rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/
     print_item "✓" "${GREEN}" "Removing Xcode caches..."
@@ -720,13 +727,18 @@ estimate_all() {
     kb=$(du_kb_sum \
         "$HOME/Library/Developer/Xcode/DerivedData" \
         "$HOME/Library/Developer/CoreSimulator/Devices" \
+        "$HOME/Library/Developer/CoreSimulator/Caches"/* \
         "$HOME/Library/Developer/Xcode/iOS DeviceSupport" \
         "$HOME/Library/Caches/com.apple.dt.Xcode" \
         "$HOME/Library/Developer/Xcode/Archives" \
         "$HOME/Library/Developer/Xcode/Products" \
         "$HOME/Library/Developer/Xcode/DocumentationCache" \
         "$HOME/Library/Containers/com.apple.CoreDevice.CoreDeviceService/Data/Library/Caches"/*)
-    set_estimate xcode "$(human_kb "$kb")"
+    # System CoreSimulator cache lives under /Library and needs sudo (already
+    # primed by main_loop). Add it to the same figure so the estimate matches
+    # what cleanup_xcode removes.
+    kb=$((kb + $(sudo_du_kb_sum /Library/Developer/CoreSimulator/Caches/*)))
+    set_estimate xcode "~$(human_kb "$kb")"
     total=$((total + kb))
 
     print_item "•" "${FAINT}" "Measuring Android/Gradle caches..."


### PR DESCRIPTION
## Summary
Adds the two CoreSimulator cache locations that the standalone `clean-xcode.sh` cleared but `dev-cleaner` did not:

- `~/Library/Developer/CoreSimulator/Caches/*` — user simulator caches
- `/Library/Developer/CoreSimulator/Caches/*` — system simulator caches (via `sudo`)

The existing aggressive behaviour (removing the entire `CoreSimulator/Devices/` folder) is intentionally **kept as-is** — this PR only adds the missing caches.

Both paths are added to the `xcode` space estimate. The system path is measured with `sudo_du_kb_sum` (sudo is already primed by `main_loop`), so the estimate is now marked approximate (`~`).

## Notes
- A short reminder is printed to close Xcode/Simulator before clearing the system cache (files may be in use).
- Uses the existing `safe_rm` / `safe_sudo_rm` primitives, so `--dry-run` and freed-space tracking work automatically. The `safe_sudo_rm .../Caches/*` call mirrors the existing `cleanup_system_junk` pattern.
- macOS-only change: `dev-cleaner.ps1` has no Xcode section (Xcode does not exist on Windows), so nothing to align there.

## Testing
- `bash -n` and `shellcheck -S error` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRbtQmJp9cvV4hmNBp9jNn