### PR TITLE
feat: add NuGet cache cleanup and VSCode VSIX cache

### DIFF
--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -465,6 +465,25 @@ cleanup_npm_yarn() {
     fi
 }
 
+cleanup_nuget() {
+    if command -v dotnet &> /dev/null; then
+        print_item "✓" "${GREEN}" "Clearing all NuGet caches (global-packages, http-cache, temp, plugins)..."
+        # NuGet has no --dry-run; honour the flag manually like cleanup_docker.
+        # 'all' covers global-packages (extracted packages, the bulk),
+        # http-cache, temp and plugins-cache; all re-created on next restore.
+        # Matches the Windows dev-cleaner.ps1 which also clears 'all'.
+        if $DRY_RUN; then
+            dotnet nuget locals all --list 2>/dev/null | sed 's/^[a-z-]*: //' | tr -d '\r' | while read -r nuget_dir; do
+                [ -n "$nuget_dir" ] && echo -e "${YELLOW}[DRY-RUN] Would clear NuGet cache: ${nuget_dir}${NC}"
+            done
+        else
+            dotnet nuget locals all --clear
+        fi
+    else
+        print_item "✕" "${YELLOW}" "dotnet (NuGet) not found. Skipping."
+    fi
+}
+
 cleanup_homebrew() {
     if command -v brew &> /dev/null; then
         print_item "✓" "${GREEN}" "Cleaning Homebrew (brew)..."
@@ -491,6 +510,8 @@ cleanup_ide_caches() {
     safe_rm -r "$HOME/Library/Application Support/Code/Cache/"
     safe_rm -r "$HOME/Library/Application Support/Code/CachedData/"
     safe_rm -r "$HOME/Library/Application Support/Code/User/workspaceStorage/"
+    # Downloaded extension .vsix installers; re-fetched if an extension reinstalls.
+    safe_rm -r "$HOME/Library/Application Support/Code/CachedExtensionVSIXs/"
 }
 
 cleanup_system_junk() {
@@ -786,6 +807,20 @@ estimate_all() {
     set_estimate npm "~$(human_kb "$npm_kb")"
     total=$((total + npm_kb))
 
+    print_item "•" "${FAINT}" "Measuring NuGet caches..."
+    local nuget_kb=0 nuget_dir
+    if command -v dotnet >/dev/null 2>&1; then
+        # Enumerate the actual local cache dirs so the estimate matches what
+        # `dotnet nuget locals all --clear` removes (paths are platform-specific).
+        while IFS= read -r nuget_dir; do
+            [ -n "$nuget_dir" ] && nuget_kb=$((nuget_kb + $(du_kb_sum "$nuget_dir")))
+        done < <(dotnet nuget locals all --list 2>/dev/null | sed 's/^[a-z-]*: //' | tr -d '\r')
+    fi
+    # Fallback to the default global-packages dir if enumeration turned up nothing.
+    [ "$nuget_kb" -gt 0 ] || nuget_kb=$(du_kb_sum "$HOME/.nuget/packages")
+    set_estimate nuget "$(human_kb "$nuget_kb")"
+    total=$((total + nuget_kb))
+
     print_item "•" "${FAINT}" "Measuring Homebrew cache..."
     local brew_kb=0 brew_cache
     if command -v brew >/dev/null 2>&1; then
@@ -807,7 +842,8 @@ estimate_all() {
         "$HOME/Library/Caches/JetBrains" \
         "$HOME/Library/Application Support/Code/Cache" \
         "$HOME/Library/Application Support/Code/CachedData" \
-        "$HOME/Library/Application Support/Code/User/workspaceStorage")
+        "$HOME/Library/Application Support/Code/User/workspaceStorage" \
+        "$HOME/Library/Application Support/Code/CachedExtensionVSIXs")
     set_estimate ide "$(human_kb "$kb")"
     total=$((total + kb))
 
@@ -954,10 +990,11 @@ display_menu() {
     echo -e "${GREEN}15.${NC} Clear Docker (prune containers, dangling images & build cache; asks before removing unused tagged images)$(est docker)"
     echo -e "${GREEN}16.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
     echo -e "${GREEN}17.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
+    echo -e "${GREEN}18.${NC} Clear .NET NuGet Caches (global-packages, http-cache, temp, plugins)$(est nuget)"
     echo ""
     echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
     echo ""
-    echo -e "→ Please enter your choice (0-17, or 99 to estimate): ${NC}\c"
+    echo -e "→ Please enter your choice (0-18, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -1025,6 +1062,7 @@ main_loop() {
                 cleanup_flutter "$FLUTTER_SEARCH_DIR"
                 cleanup_platformIO
                 cleanup_npm_yarn
+                cleanup_nuget
                 cleanup_homebrew
                 cleanup_cocoapods
                 cleanup_ide_caches
@@ -1141,6 +1179,10 @@ main_loop() {
                 print_section_header "Performing Time Machine Snapshots Cleanup"
                 cleanup_timemachine_snapshots
                 ;;
+            18)
+                print_section_header "Performing .NET NuGet Cleanup"
+                cleanup_nuget
+                ;;
             99)
                 print_section_header "Estimating Reclaimable Space"
                 estimate_all
@@ -1149,7 +1191,7 @@ main_loop() {
                 continue
                 ;;
             *)
-                echo -e "${RED}Invalid choice. Please enter a number between 0 and 17.${NC}"
+                echo -e "${RED}Invalid choice. Please enter a number between 0 and 18.${NC}"
                 sleep 2
                 ;;
         esac


### PR DESCRIPTION
## Summary
Brings `dev-cleaner.sh` up to parity with the Windows `dev-cleaner.ps1`, which already covered both of these — closing two items from the old `dev-clean-scripts` todo:

- **New menu option 18 — "Clear .NET NuGet Caches"**: runs `dotnet nuget locals all --clear` (global-packages, http-cache, temp, plugins-cache). Honours `--dry-run` manually (like `cleanup_docker`) and skips cleanly when `dotnet` is not installed. Also added to the "Clear All" path.
- **VSCode `CachedExtensionVSIXs`**: added to the existing IDE cache cleanup (option 8) — downloaded `.vsix` installers, re-fetched on demand.

Both get matching space estimates:
- NuGet enumerates the *actual* local cache dirs via `dotnet nuget locals all --list` (paths are platform-specific), with a `~/.nuget/packages` fallback, so the estimate matches what the clear removes.
- VSIX is folded into the `ide` estimate.

Menu range prompts updated `0-17` → `0-18`.

## `.ps1`
No changes needed — `dev-cleaner.ps1` already has `Clear-NuGet` (clears `all`) wired as menu item 7 and the `CachedExtensionVSIXs` path in `Clear-IdeCaches`, both with estimates. This PR aligns the `.sh` to that same scope (`all`).

## Testing
- `bash -n` and `shellcheck -S error` pass clean.
- Exercised `cleanup_nuget` and the NuGet estimate against a stubbed `dotnet` emitting a realistic `nuget locals all --list`: dry-run enumerates every cache dir and deletes nothing; estimate sums the existing cache dirs; real path invokes `dotnet nuget locals all --clear`; `dotnet` absent → clean skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRbtQmJp9cvV4hmNBp9jNn