### PR TITLE
fix: handle Full Disk Access denial on system CoreSimulator cache

### DIFF
--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -87,6 +87,29 @@ get_disk_space() {
     df -h . | awk 'NR==2 {print $4}'
 }
 
+# macOS refuses to delete parts of /Library (notably the CoreSimulator dyld
+# cache) unless the *terminal app* running this script holds Full Disk Access.
+# The check is TCC/per-app, not per-user, so sudo alone does not lift it and
+# rm fails with EPERM. Reading the TCC database is the canonical probe.
+# Memoized: the answer cannot change while the script runs.
+FULL_DISK_ACCESS=""
+has_full_disk_access() {
+    [ "$(uname)" = "Darwin" ] || return 0
+    if [ -z "$FULL_DISK_ACCESS" ]; then
+        if head -c 1 "/Library/Application Support/com.apple.TCC/TCC.db" >/dev/null 2>&1; then
+            FULL_DISK_ACCESS="yes"
+        else
+            FULL_DISK_ACCESS="no"
+        fi
+    fi
+    [ "$FULL_DISK_ACCESS" = "yes" ]
+}
+
+print_full_disk_access_hint() {
+    print_item "→" "${CYAN}" "Grant Full Disk Access to your terminal, then re-run:"
+    echo -e "  ${FAINT}System Settings → Privacy & Security → Full Disk Access → enable your terminal app (Terminal, iTerm, VS Code…), then restart it.${NC}"
+}
+
 # --- Estimation helpers (read-only: never delete anything) ---
 
 # Format a size given in KB into a human-readable string using the same
@@ -227,9 +250,12 @@ safe_rm() {
 }
 
 # Dry-run aware sudo file/directory removal
+# Returns non-zero if any removal failed (e.g. macOS denied it), so callers
+# can print an actionable hint instead of leaving raw rm errors on screen.
 # Usage: safe_sudo_rm [-r] <path> [<path> ...]
 safe_sudo_rm() {
     local recursive=""
+    local status=0
     local paths=()
     
     # Parse arguments
@@ -270,14 +296,16 @@ safe_sudo_rm() {
                     fi
                 else
                     if [[ -n "$recursive" ]]; then
-                        sudo rm -rf "$expanded_path"
+                        sudo rm -rf "$expanded_path" || status=1
                     else
-                        sudo rm -f "$expanded_path"
+                        sudo rm -f "$expanded_path" || status=1
                     fi
                 fi
             fi
         done
     done
+
+    return $status
 }
 
 # --- Cleanup Functions ---
@@ -288,11 +316,23 @@ cleanup_xcode() {
     safe_rm -rf ~/Library/Developer/CoreSimulator/Devices/
     print_item "✓" "${GREEN}" "Removing CoreSimulator caches..."
     safe_rm -rf ~/Library/Developer/CoreSimulator/Caches/*
-    # System-level CoreSimulator cache lives under /Library and needs sudo.
+    # System-level CoreSimulator cache lives under /Library and needs sudo *and*
+    # Full Disk Access; without the latter macOS denies every unlink and rm
+    # floods the screen with "Operation not permitted". Check first, then act.
     # Close Xcode/Simulator first so we don't clear files still in use.
-    print_item "ℹ️" "${YELLOW}" "Make sure Xcode and Simulator are closed before clearing the system CoreSimulator cache."
-    print_item "✓" "${GREEN}" "Removing system CoreSimulator caches (sudo)..."
-    safe_sudo_rm -rf /Library/Developer/CoreSimulator/Caches/*
+    if compgen -G "/Library/Developer/CoreSimulator/Caches/*" >/dev/null; then
+        if has_full_disk_access; then
+            print_item "ℹ️" "${YELLOW}" "Make sure Xcode and Simulator are closed before clearing the system CoreSimulator cache."
+            print_item "✓" "${GREEN}" "Removing system CoreSimulator caches (sudo)..."
+            if ! safe_sudo_rm -rf /Library/Developer/CoreSimulator/Caches/* 2>/dev/null; then
+                print_item "✕" "${YELLOW}" "System CoreSimulator cache could not be removed: macOS denied it even with sudo."
+                print_item "→" "${CYAN}" "Quit Xcode and Simulator and try again; it is rebuilt automatically on next simulator launch."
+            fi
+        else
+            print_item "✕" "${YELLOW}" "Skipping system CoreSimulator cache: macOS blocks it without Full Disk Access."
+            print_full_disk_access_hint
+        fi
+    fi
     print_item "✓" "${GREEN}" "Removing old device support files..."
     safe_rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/
     print_item "✓" "${GREEN}" "Removing Xcode caches..."
@@ -764,9 +804,11 @@ estimate_all() {
         "$HOME/Library/Developer/Xcode/DocumentationCache" \
         "$HOME/Library/Containers/com.apple.CoreDevice.CoreDeviceService/Data/Library/Caches"/*)
     # System CoreSimulator cache lives under /Library and needs sudo (already
-    # primed by main_loop). Add it to the same figure so the estimate matches
-    # what cleanup_xcode removes.
-    kb=$((kb + $(sudo_du_kb_sum /Library/Developer/CoreSimulator/Caches/*)))
+    # primed by main_loop) plus Full Disk Access. Only count it when cleanup can
+    # actually delete it, so the estimate never promises unreclaimable space.
+    if has_full_disk_access; then
+        kb=$((kb + $(sudo_du_kb_sum /Library/Developer/CoreSimulator/Caches/*)))
+    fi
     set_estimate xcode "~$(human_kb "$kb")"
     total=$((total + kb))
 


### PR DESCRIPTION
Fixes #52

## Problem

The Xcode cleanup printed a wall of `rm: ... Operation not permitted` errors while clearing the system CoreSimulator cache, deleted nothing, and still counted that space in the estimate.

The path is **not** SIP-protected — it carries no `restricted` flag, unlike paths that genuinely are:

```console
$ ls -lOd /Library/Developer/CoreSimulator/Caches/dyld
drwxr-xr-x@ 3 root wheel - 96 Jul 10 21:21 /Library/Developer/CoreSimulator/Caches/dyld

$ ls -lOd /usr/libexec
drwxr-xr-x 431 root wheel restricted 13792 Jun 25 04:29 /usr/libexec
```

The gate is TCC: macOS allows deleting that subtree only from a process whose *host application* holds Full Disk Access. The check is per-app, not per-user, so `sudo` does not lift it and every `unlink()` returns `EPERM`. No terminal app has Full Disk Access by default, so this hits every user who has not granted it manually.

## Changes

- **`has_full_disk_access()`** — new memoized helper that probes Full Disk Access by reading `/Library/Application Support/com.apple.TCC/TCC.db`, the canonical check. Returns success on non-Darwin so nothing else changes there.
- **`cleanup_xcode()`** — checks before attempting. Without Full Disk Access it skips the system CoreSimulator step and prints how to grant it, instead of running a removal that is guaranteed to fail. With access granted but the removal still failing (Xcode/Simulator running), `stderr` is suppressed in favour of a dedicated message. The whole block is also guarded by `compgen -G`, so machines without that cache stay silent.
- **`safe_sudo_rm()`** — now tracks failures and returns non-zero, so callers can react instead of silently ignoring `rm`'s exit status. Behaviour is otherwise unchanged for every existing call site.
- **`estimate_all()`** — includes the system cache in the Xcode figure only when it is actually deletable. Previously it promised ~3.2 GB that the cleanup could never reclaim.

## Output after the fix

Without Full Disk Access, the ten `rm:` lines are replaced by:

```
✕ Skipping system CoreSimulator cache: macOS blocks it without Full Disk Access.
→ Grant Full Disk Access to your terminal, then re-run:
  System Settings → Privacy & Security → Full Disk Access → enable your terminal app (Terminal, iTerm, VS Code…), then restart it.
```

## Testing

- `bash -n dev-cleaner.sh` passes.
- `shellcheck -S warning` reports nothing new; the six remaining warnings are pre-existing.
- Verified the no-access path emits the message above on macOS 26.5 (Apple Silicon, SIP enabled).
- The access-granted path was not exercised end to end, since that requires a terminal with Full Disk Access; the branch is a direct reuse of the previous `safe_sudo_rm` call with its exit status now checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159D5nd8mhMZw1Ee2Mzb9vf
