### PR TITLE
feat: empty the Homebrew download cache with --prune=all

### DIFF
--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -542,7 +542,21 @@ cleanup_nuget() {
 cleanup_homebrew() {
     if command -v brew &> /dev/null; then
         print_item "✓" "${GREEN}" "Cleaning Homebrew (brew)..."
-        brew cleanup
+        # --prune=all empties the whole download cache (bottles, casks, bottle
+        # manifests) instead of only entries older than 120 days
+        # (HOMEBREW_CLEANUP_MAX_AGE_DAYS), which on a recently-updated machine
+        # frees nothing at all. Everything there is re-downloadable from
+        # Homebrew's CDN, so the only cost is bandwidth on the next
+        # install/upgrade. It is also what estimate_all() measures below, so
+        # plain `brew cleanup` made the estimate promise space it would not
+        # reclaim.
+        # brew has a native dry-run, so use it instead of a manual guard.
+        if $DRY_RUN; then
+            echo -e "${YELLOW}[DRY-RUN] Would run: brew cleanup --prune=all${NC}"
+            brew cleanup --prune=all --dry-run
+        else
+            brew cleanup --prune=all
+        fi
     else
         print_item "✕" "${YELLOW}" "Homebrew not found. Skipping."
     fi
@@ -890,7 +904,13 @@ estimate_all() {
     local brew_kb=0 brew_cache
     if command -v brew >/dev/null 2>&1; then
         brew_cache="$(brew --cache 2>/dev/null)"
-        [ -n "$brew_cache" ] && brew_kb=$(du_kb_sum "$brew_cache")
+        if [ -n "$brew_cache" ]; then
+            brew_kb=$(du_kb_sum "$brew_cache")
+            # `brew cleanup --prune=all` empties the download cache but leaves
+            # the JSON API metadata and the bootsnap compile cache in place, so
+            # they are not reclaimable and must not be counted here.
+            brew_kb=$((brew_kb - $(du_kb_sum "$brew_cache/api" "$brew_cache/bootsnap")))
+        fi
     fi
     set_estimate homebrew "~$(human_kb "$brew_kb")"
     total=$((total + brew_kb))
@@ -1043,7 +1063,7 @@ display_menu() {
     echo -e "${GREEN} 3.${NC} Clear Android/Gradle Caches$(est android)"
     echo -e "${GREEN} 4.${NC} Clear Flutter Caches ${FAINT}(with custom directory option)${NC}$(est flutter)"
     echo -e "${GREEN} 5.${NC} Clear npm/Yarn/pnpm Caches$(est npm)"
-    echo -e "${GREEN} 6.${NC} Clean Homebrew Caches$(est homebrew)"
+    echo -e "${GREEN} 6.${NC} Clean Homebrew Caches ${FAINT}(removes all cached downloads)${NC}$(est homebrew)"
     echo -e "${GREEN} 7.${NC} Clear CocoaPods Caches$(est cocoapods)"
     echo -e "${GREEN} 8.${NC} Clear IDE (JetBrains, VSCode) Caches$(est ide)"
     echo -e "${GREEN} 9.${NC} Clean System Junk & Logs (requires sudo)$(est system)"


### PR DESCRIPTION
Closes #38

`brew cleanup` only removes downloads older than 120 days (`HOMEBREW_CLEANUP_MAX_AGE_DAYS`) plus outdated versions of installed formulae, so on a recently-updated machine it frees nothing at all.

Measured locally (Homebrew 5.1.11):

| command | freed |
| --- | --- |
| `brew cleanup` | 0 |
| `brew cleanup --prune=all` | **517 MB** (cache 550 MB → 57 MB) |

@0x1af2aec8f957 reports 8.3 GB followed by a further 66 GB on their machine.

Everything in that cache is re-downloadable from Homebrew's CDN, so the only cost is bandwidth on the next install/upgrade — the same trade-off the script already makes for the npm, CocoaPods and Gradle caches. `brew autoremove` was deliberately left out: it uninstalls packages from the Cellar, it is not a cache.

### Two related fixes in the same code paths

- **`cleanup_homebrew()` ignored `$DRY_RUN`** and deleted files during a `--dry-run` run. It now uses brew's native `--dry-run`, matching how `cleanup_nuget` and `cleanup_docker` honour the flag. This mattered more with `--prune=all`, since the bug would have wiped the whole cache.
- **`estimate_all()` measured the whole `brew --cache`**, i.e. exactly what `--prune=all` reclaims and not what plain `brew cleanup` did — so option 6 could advertise "~550MB" and then free 0. It now also subtracts `api/` and `bootsnap/`, the only two subdirectories `--prune=all` leaves in place, so the estimate reads 0 right after a cleanup instead of ~57 MB.

Menu entry 6 is relabelled `Clean Homebrew Caches (removes all cached downloads)` so the more thorough behaviour is visible before running it.

### Verification

- `bash -n` clean; `shellcheck -S warning` reports nothing on the new lines (existing warnings are pre-existing).
- `--dry-run`: 52 files listed, cache unchanged at 550 MB.
- Real run: 550 MB → 57 MB, brew fully functional afterwards (`brew --version`, `brew list`).
- Missing-Homebrew branch still prints `Homebrew not found. Skipping.`

`dev-cleaner.ps1` is untouched (no Homebrew on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013u5NyFbiDUzE8vh644p7ch