### PR TITLE
feat: prune old Claude Code versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This tool is for **educational purposes**, focusing on safely removing developme
   * Android Gradle caches (`android/.gradle`, `android/build`, `android/app/build`)
   * iOS CocoaPods caches (`ios/Pods`, `ios/Podfile.lock`, `ios/.symlinks`, Flutter frameworks)
   * Global Flutter cache
+* **AI CLI Tools:** Prunes the old Claude Code binaries the native installer leaves behind (`~/.local/share/claude/versions`, ~190 MB per release), keeping the version in use.
 * **Interactive Menu:** Allows selection of specific cleanup targets (e.g., Xcode only).
 * **Multi-platform Support:** Supports **macOS**, **Linux**, and **Windows**.
 
@@ -149,6 +150,15 @@ The Windows version includes all cross-platform cleanups plus:
 - **Windows Temp:** Clears user and system temp folders, plus Recycle Bin
 
 > **Note:** Some operations require Administrator privileges. The script will automatically request elevation if needed.
+
+#### 🤖 Claude Code Version Cleanup
+
+Claude Code's native installer keeps every version it has ever installed under `~/.local/share/claude/versions/` and never removes the old ones, so weeks of background auto-updates quietly cost several GB. Option 19 (option 12 on Windows) prunes them. Because one of those files is the binary the `claude` command actually runs, this option is deliberately conservative:
+
+- **Always kept:** the version the launcher (`~/.local/bin/claude`) resolves to, and any binary a running session still has open.
+- **Also kept on Windows:** the newest file, since there is no symlink to resolve and an update can land in `versions\` without being copied into `bin\`.
+- **Skipped entirely** — nothing is removed, with a warning — when the launcher is not a symlink into `versions/` (you replaced it with your own script) or points at a version that is no longer on disk. The active version cannot be identified, so nothing is guessed.
+- **Never touched:** `~/.claude/` and `~/.claude.json`. Settings, MCP configuration and session history live there.
 
 #### 🧹 Flutter Cleanup Details
 

--- a/check-storage.sh
+++ b/check-storage.sh
@@ -29,5 +29,9 @@ echo "🎵 Spotify Cache:"
 du -sh ~/Library/Caches/com.spotify.client 2>/dev/null || echo "None found"
 echo ""
 
+echo "🤖 Claude Code versions:"
+du -sh ~/.local/share/claude/versions 2>/dev/null || echo "None found"
+echo ""
+
 echo "📦 Largest directories in ~/Library:"
 du -sh ~/Library/* 2>/dev/null | sort -hr | head -10

--- a/dev-cleaner.ps1
+++ b/dev-cleaner.ps1
@@ -654,6 +654,103 @@ function Clear-Electron {
     }
 }
 
+# Claude Code's native installer keeps every version it has ever installed
+# under versions\ and never removes the old ones (~190 MB per release). Unlike
+# every other target in this script that is NOT a cache directory: one of those
+# files is the binary the `claude` command actually runs.
+# There is no symlink to resolve on Windows (.local\bin\claude.exe is a COPY of
+# the version in use), so the active one is identified by size and then SHA256.
+# Read-only. Shared by Clear-ClaudeCode and Invoke-EstimateAll so the estimate
+# and the cleanup cannot drift apart.
+# Status: 'missing' (not installed) | 'unknown' (custom launcher: skip the
+# target entirely) | 'ok' (Files is authoritative, possibly empty).
+function Get-ClaudeRemovableVersions {
+    $versionsDir = "$env:USERPROFILE\.local\share\claude\versions"
+    $launcher    = "$env:USERPROFILE\.local\bin\claude.exe"
+
+    if (-not (Test-Path $versionsDir)) {
+        return [PSCustomObject]@{ Status = 'missing'; ActiveName = $null; Files = @(); InUse = @() }
+    }
+    if (-not (Test-Path $launcher)) {
+        return [PSCustomObject]@{ Status = 'unknown'; ActiveName = $null; Files = @(); InUse = @() }
+    }
+
+    $files = @(Get-ChildItem -Path $versionsDir -File -Force -ErrorAction SilentlyContinue)
+    if ($files.Count -eq 0) {
+        return [PSCustomObject]@{ Status = 'ok'; ActiveName = $null; Files = @(); InUse = @() }
+    }
+
+    # Hash only the candidates of exactly the launcher's size: hashing 200 MB
+    # binaries that cannot possibly match is pure I/O.
+    $launcherItem = Get-Item -LiteralPath $launcher -Force -ErrorAction SilentlyContinue
+    $active = $null
+    if ($launcherItem) {
+        $launcherHash = (Get-FileHash -LiteralPath $launcher -Algorithm SHA256 -ErrorAction SilentlyContinue).Hash
+        if ($launcherHash) {
+            foreach ($f in ($files | Where-Object { $_.Length -eq $launcherItem.Length })) {
+                $h = (Get-FileHash -LiteralPath $f.FullName -Algorithm SHA256 -ErrorAction SilentlyContinue).Hash
+                if ($h -eq $launcherHash) { $active = $f; break }
+            }
+        }
+    }
+    # No match means the launcher is not one of these binaries: the user
+    # replaced it with their own, exactly like a non-symlink launcher on
+    # macOS/Linux. The version in use cannot be identified, so skip.
+    if (-not $active) {
+        return [PSCustomObject]@{ Status = 'unknown'; ActiveName = $null; Files = @(); InUse = @() }
+    }
+
+    # Keep the newest file as well: an update can land in versions\ without
+    # being copied into bin\, so the newest one may legitimately not be the
+    # one currently running.
+    $newest = $files | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+    # Binaries an older session is still running from. $_.Path throws Access
+    # Denied for other users' processes, and an exception raised inside the
+    # pipeline would abort it and silently skip every process after it, so the
+    # guard sits inside the scriptblock, per element, never around the pipeline.
+    $inUse = @(Get-Process -ErrorAction SilentlyContinue |
+               Where-Object { try { $_.Path -like "$versionsDir\*" } catch { $false } } |
+               ForEach-Object { try { $_.Path } catch { $null } })
+
+    $removable = @($files | Where-Object {
+        $_.FullName -ne $active.FullName -and
+        $_.FullName -ne $newest.FullName -and
+        $inUse -notcontains $_.FullName
+    })
+
+    return [PSCustomObject]@{ Status = 'ok'; ActiveName = $active.Name; Files = $removable; InUse = $inUse }
+}
+
+# Prunes %USERPROFILE%\.local\share\claude\versions, keeping the version in use,
+# the newest one, and anything a running session still holds open.
+# Never touches %USERPROFILE%\.claude\ or .claude.json: settings, MCP config
+# and session history live there.
+function Clear-ClaudeCode {
+    $info = Get-ClaudeRemovableVersions
+
+    if ($info.Status -eq 'missing') {
+        Write-Item "✕" "Yellow" "Claude Code not found. Skipping."
+        return
+    }
+    if ($info.Status -eq 'unknown') {
+        Write-Item "✕" "Yellow" "Claude Code: the version in use cannot be identified (custom launcher). Skipping."
+        return
+    }
+    if ($info.InUse.Count -gt 0) {
+        Write-Item "→" "Cyan" "Claude Code: $($info.InUse.Count) version(s) still running; keeping them."
+    }
+    if ($info.Files.Count -eq 0) {
+        Write-Item "✓" "Green" "Claude Code: nothing to prune."
+        return
+    }
+
+    Write-Item "✓" "Green" "Removing old Claude Code versions (keeping $($info.ActiveName) and the newest one)..."
+    foreach ($f in $info.Files) {
+        Remove-SafelyWithTracking -Path $f.FullName -Description "Claude Code version: $($f.Name)"
+    }
+}
+
 # -Interactive offers the deeper `prune -af` via a secondary prompt. "Clear All
 # Caches" calls this without it, so a bulk run never deletes tagged images by
 # surprise.
@@ -844,6 +941,20 @@ function Invoke-EstimateAll {
     $b = Get-PathSizeBytes $electronCache
     Set-Estimate "electron" (Format-Size $b); $total += $b
 
+    # Claude Code old versions
+    Write-Host "  Measuring Claude Code old versions..." -ForegroundColor DarkGray
+    $claudeInfo = Get-ClaudeRemovableVersions
+    if ($claudeInfo.Status -eq 'unknown') {
+        # Not measurable, so not added to the byte total, like the Docker
+        # "daemon not running" case below.
+        Set-Estimate "claudecode" "n/a (custom launcher)"
+    } else {
+        $claudePaths = @()
+        foreach ($f in $claudeInfo.Files) { $claudePaths += $f.FullName }
+        $b = Get-PathSizeBytes $claudePaths
+        Set-Estimate "claudecode" (Format-Size $b); $total += $b
+    }
+
     # Docker is not path-based: ask docker itself (read-only). Two figures,
     # because option 11 offers two prune modes:
     #   -f  : build-cache reclaimable + dangling (untagged) images
@@ -944,16 +1055,18 @@ function Show-Menu {
     Write-Host (" 9. Clear Cordova tmp files" + (Get-Est 'cordova')) -ForegroundColor Green
     Write-Host ("10. Clear Electron cache" + (Get-Est 'electron')) -ForegroundColor Green
     Write-Host ("11. Clear Docker (prune containers, dangling images & build cache; asks before removing unused tagged images)" + (Get-Est 'docker')) -ForegroundColor Green
+    Write-Host "─── AI CLI Tools ───" -ForegroundColor DarkGray
+    Write-Host ("12. Clear old Claude Code versions (keeps the version in use)" + (Get-Est 'claudecode')) -ForegroundColor Green
     Write-Host "─── IDEs & Editors ───" -ForegroundColor DarkGray
-    Write-Host ("12. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
+    Write-Host ("13. Clear IDE Caches (JetBrains, VSCode)" + (Get-Est 'ide')) -ForegroundColor Green
     Write-Host "─── System ───" -ForegroundColor DarkGray
-    Write-Host ("13. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
-    Write-Host ("14. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
-    Write-Host ("15. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
+    Write-Host ("14. Clean Windows Temp & Recycle Bin" + (Get-Est 'windowstemp')) -ForegroundColor Green
+    Write-Host ("15. Clear Browser Caches (Chrome, Edge, Firefox, Brave, Opera)" + (Get-Est 'browser')) -ForegroundColor Green
+    Write-Host ("16. Clean App Caches (Slack, Teams, Discord, Spotify, WhatsApp)" + (Get-Est 'appcontainers')) -ForegroundColor Green
     Write-Host ""
     Write-Host "99. Estimate reclaimable space (read-only, ~ = approximate)" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "→ Please enter your choice (0-15, or 99 to estimate): " -NoNewline
+    Write-Host "→ Please enter your choice (0-16, or 99 to estimate): " -NoNewline
 }
 
 # --- Main Loop ---
@@ -982,6 +1095,7 @@ function Start-MainLoop {
                 Clear-PlatformIO
                 Clear-Cordova
                 Clear-Electron
+                Clear-ClaudeCode
                 Clear-Docker
                 Clear-IdeCaches
                 Clear-WindowsTemp
@@ -1057,18 +1171,22 @@ function Start-MainLoop {
                 Clear-Docker -Interactive
             }
             "12" {
+                Write-SectionHeader "Performing Claude Code Version Cleanup"
+                Clear-ClaudeCode
+            }
+            "13" {
                 Write-SectionHeader "Performing IDE Caches Cleanup"
                 Clear-IdeCaches
             }
-            "13" {
+            "14" {
                 Write-SectionHeader "Performing Windows Temp & Recycle Bin Cleanup"
                 Clear-WindowsTemp
             }
-            "14" {
+            "15" {
                 Write-SectionHeader "Performing Browser Caches Cleanup"
                 Clear-BrowserCaches
             }
-            "15" {
+            "16" {
                 Write-SectionHeader "Performing App Caches Cleanup"
                 Clear-AppContainers
             }
@@ -1080,7 +1198,7 @@ function Start-MainLoop {
                 continue
             }
             default {
-                Write-Host "Invalid choice. Please enter a number between 0 and 15." -ForegroundColor Red
+                Write-Host "Invalid choice. Please enter a number between 0 and 16." -ForegroundColor Red
                 Start-Sleep -Seconds 2
                 continue
             }

--- a/dev-cleaner.sh
+++ b/dev-cleaner.sh
@@ -211,6 +211,81 @@ brew_reclaimable_kb() {
     [ "$kb" -gt 0 ] && echo "$kb" || echo 0
 }
 
+# --- Claude Code versions ---
+# Claude Code's native installer keeps every version it has ever installed
+# under versions/ and never removes the old ones (~190 MB per release). Unlike
+# every other target in this script that is NOT a cache directory: one of those
+# files is the binary the `claude` command actually runs, so the active version
+# must survive. These two helpers are read-only and are the single source of
+# truth for "what is deletable", shared by estimate_all() and
+# cleanup_claude_code() so the estimate and the cleanup cannot drift apart.
+CLAUDE_VERSIONS_DIR="$HOME/.local/share/claude/versions"
+CLAUDE_LAUNCHER="$HOME/.local/bin/claude"
+
+# Echo the versions/<release> file the launcher resolves to. Read-only.
+#   rc 0 -> path echoed
+#   rc 1 -> versions/ does not exist (Claude Code not installed this way)
+#   rc 2 -> active version undeterminable; the caller must skip the target
+claude_active_version() {
+    [ -d "$CLAUDE_VERSIONS_DIR" ] || return 1
+    # A regular file (or nothing) means the user replaced the launcher with
+    # their own script or binary. Claude Code itself then keeps every version
+    # on disk because it cannot tell which one that launcher needs, and
+    # neither can we.
+    [ -L "$CLAUDE_LAUNCHER" ] || return 2
+    # A dangling launcher names a version that is no longer on disk, so the
+    # active one cannot be identified: skip rather than prune everything.
+    [ -e "$CLAUDE_LAUNCHER" ] || return 2
+
+    local target dir versions_dir
+    target=$(readlink "$CLAUDE_LAUNCHER") || return 2
+    # readlink may hand back a path relative to the link's own directory
+    case "$target" in
+        /*) ;;
+        *) target="$(dirname "$CLAUDE_LAUNCHER")/$target" ;;
+    esac
+    # Resolve ".." and symlinked parents on both sides before comparing them:
+    # a relative link reads "../share/claude/versions/<x>", which as a plain
+    # string never prefix-matches $CLAUDE_VERSIONS_DIR.
+    dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 2
+    versions_dir="$(cd "$CLAUDE_VERSIONS_DIR" 2>/dev/null && pwd -P)" || return 2
+    # A launcher pointing anywhere but straight into versions/ is someone
+    # else's launcher too.
+    [ -n "$dir" ] && [ "$dir" = "$versions_dir" ] || return 2
+
+    echo "$dir/$(basename "$target")"
+}
+
+# Echo one removable version file per line. Read-only.
+# An empty list with rc 0 is a valid answer: only the active version is left.
+# Same rc contract as claude_active_version().
+claude_removable_versions() {
+    local active status active_name
+    active=$(claude_active_version); status=$?
+    [ $status -eq 0 ] || return $status
+    active_name="$(basename "$active")"
+
+    local f
+    for f in "$CLAUDE_VERSIONS_DIR"/*; do
+        # Skips subdirectories and the unexpanded glob of an empty directory
+        [ -f "$f" ] || continue
+        # Compared by name, not by path string: $active is canonical while $f
+        # is spelled as the glob produced it, and both are known to sit
+        # directly in versions/, where names are unique.
+        [ "$(basename "$f")" = "$active_name" ] && continue
+        # An older session may still be running from an old binary. `pgrep -x
+        # claude` cannot find it: the files are named after the release, so the
+        # process name is e.g. "2.1.258", not "claude". lsof on the file is the
+        # reliable test. stderr is always dropped ("can't stat()" warnings
+        # would land in the middle of the menu output).
+        if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -- "$f" 2>/dev/null)" ]; then
+            continue
+        fi
+        echo "$f"
+    done
+    return 0
+}
+
 # --- Reclaimed-space accounting ---
 # Free space (df) is a poor progress meter for a cleaner on macOS: on APFS the
 # blocks of a deleted file stay allocated as long as a Time Machine local
@@ -869,6 +944,38 @@ cleanup_electron() {
     fi
 }
 
+# Prunes ~/.local/share/claude/versions, keeping the version the `claude`
+# launcher points at (plus any binary a running session still has open).
+# Never touches ~/.claude/ or ~/.claude.json: settings, MCP config and
+# session history live there.
+cleanup_claude_code() {
+    local out status active v
+    # Command substitution, not a pipeline: `claude_removable_versions | while
+    # read` would leave $? holding the loop's status, not the helper's.
+    out="$(claude_removable_versions)"; status=$?
+
+    if [ $status -eq 1 ]; then
+        print_item "✕" "${YELLOW}" "Claude Code not found. Skipping."
+        return
+    fi
+    if [ $status -eq 2 ]; then
+        print_item "✕" "${YELLOW}" "Claude Code: ${CLAUDE_LAUNCHER} does not resolve into versions/ (custom or missing launcher)."
+        print_item "→" "${CYAN}" "The version in use cannot be determined, so nothing is removed."
+        return
+    fi
+    if [ -z "$out" ]; then
+        print_item "✓" "${GREEN}" "Claude Code: only the version in use is installed. Nothing to prune."
+        return
+    fi
+
+    active="$(claude_active_version)"
+    print_item "✓" "${GREEN}" "Removing old Claude Code versions (keeping $(basename "$active"))..."
+    # Quoted read, never `for v in $out`: $HOME may contain spaces.
+    while IFS= read -r v; do
+        [ -n "$v" ] && safe_rm "$v"
+    done <<< "$out"
+}
+
 # Usage: cleanup_docker [interactive]
 #   no arg      -> safe `prune -f` only, no prompt (used by "Clear All Caches"
 #                  so a bulk run never deletes tagged images by surprise)
@@ -1123,6 +1230,26 @@ estimate_all() {
     set_estimate electron "$(human_kb "$kb")"
     total=$((total + kb))
 
+    print_item "•" "${FAINT}" "Measuring Claude Code old versions..."
+    local claude_out claude_status claude_v
+    local claude_paths=()
+    claude_out="$(claude_removable_versions)"; claude_status=$?
+    if [ $claude_status -eq 2 ]; then
+        # Not measurable, so not added to the byte total, like the Docker
+        # "daemon not running" case below.
+        set_estimate claude "n/a (custom launcher)"
+    else
+        # The here-string yields one empty iteration even for empty output
+        while IFS= read -r claude_v; do
+            [ -n "$claude_v" ] && claude_paths+=("$claude_v")
+        done <<< "$claude_out"
+        kb=0
+        [ ${#claude_paths[@]} -gt 0 ] && kb=$(du_kb_sum "${claude_paths[@]}")
+        # Exact file sizes, not an approximation: no "~" prefix.
+        set_estimate claude "$(human_kb "$kb")"
+        total=$((total + kb))
+    fi
+
     # Docker is not path-based: ask docker itself (read-only). Two figures,
     # because option 15 offers two prune modes:
     #   -f  : build-cache reclaimable + dangling (untagged) images
@@ -1226,10 +1353,11 @@ display_menu() {
     echo -e "${GREEN}16.${NC} Clean App Containers (Slack, Teams, Discord, Spotify, WhatsApp)$(est appcontainers)"
     echo -e "${GREEN}17.${NC} Remove Time Machine Local Snapshots (requires sudo)$(est timemachine)"
     echo -e "${GREEN}18.${NC} Clear .NET NuGet Caches (global-packages, http-cache, temp, plugins)$(est nuget)"
+    echo -e "${GREEN}19.${NC} Clear old Claude Code versions ${FAINT}(keeps the version in use)${NC}$(est claude)"
     echo ""
     echo -e "${CYAN}99.${NC} Estimate reclaimable space ${FAINT}(read-only, ~ = approximate)${NC}"
     echo ""
-    echo -e "→ Please enter your choice (0-18, or 99 to estimate): ${NC}\c"
+    echo -e "→ Please enter your choice (0-19, or 99 to estimate): ${NC}\c"
 }
 
 # --- Help function ---
@@ -1315,6 +1443,7 @@ main_loop() {
                 cleanup_browser_caches
                 cleanup_cordova
                 cleanup_electron
+                cleanup_claude_code
                 cleanup_docker
                 cleanup_app_containers
                 cleanup_timemachine_snapshots
@@ -1428,6 +1557,10 @@ main_loop() {
                 print_section_header "Performing .NET NuGet Cleanup"
                 cleanup_nuget
                 ;;
+            19)
+                print_section_header "Performing Claude Code Version Cleanup"
+                cleanup_claude_code
+                ;;
             99)
                 print_section_header "Estimating Reclaimable Space"
                 estimate_all
@@ -1436,7 +1569,7 @@ main_loop() {
                 continue
                 ;;
             *)
-                echo -e "${RED}Invalid choice. Please enter a number between 0 and 18.${NC}"
+                echo -e "${RED}Invalid choice. Please enter a number between 0 and 19.${NC}"
                 sleep 2
                 ;;
         esac


### PR DESCRIPTION
Closes #61

Claude Code's native installer keeps every version it has ever installed under `~/.local/share/claude/versions/` and never removes the old ones — ~190 MB per release. On my machine that is 568 MB across three versions, 378 MB of it reclaimable.

Unlike every other target in this tool that directory is **not** a cache: one of those files is the binary `claude` actually runs. The routine therefore resolves the active version and keeps it, and skips the whole target whenever it cannot.

### macOS / Linux — option 19

- Keeps the version `~/.local/bin/claude` resolves to. Relative link targets and symlinked parents are canonicalised on both sides before comparing, so `../share/claude/versions/<x>` is not mistaken for a foreign launcher.
- Keeps any binary a running session still has open. **`pgrep -x claude` does not work here:** the files are named after the release, so a live session's process name is e.g. `2.1.258`, and `pgrep -x claude` returns nothing. `lsof -t -- <file>` is the reliable test (~0.2 s per file), guarded by `command -v lsof` so a box without it degrades to the other rules instead of failing.
- **Skips the target entirely, with a warning,** when the launcher is not a symlink into `versions/`, or dangles. That is rule 2 of the issue: Claude Code itself keeps every version in that case because it cannot tell which one the launcher needs, and neither can we.
- Deletes through the existing `safe_rm`, so `--dry-run` and the reclaimed-space total behave like every other option.

### Windows — option 12 (menu renumbered)

There is no symlink to resolve: `.local\bin\claude.exe` is a copy. The active version is matched by `Length` first and only then by SHA256, so 200 MB binaries that cannot match are never hashed. **The newest file is kept as well**, per rule 3 of the issue — an update can land in `versions\` without being copied into `bin\`. No hash match means a custom launcher: skip. The running-process check guards `$_.Path` per element inside the `Where-Object` scriptblock, since an Access Denied on another user's process would otherwise abort the pipeline and silently skip the rest.

Menu renumbering follows the Docker PR: a new `─── AI CLI Tools ───` group at 12, with IDE/Temp/Browser/App shifting to 13-16.

### Also

- `check-storage.sh` reports the directory.
- Both estimators measure it (exact file sizes, so no `~` prefix) and show `n/a (custom launcher)` without summing when the target is skipped.
- README documents what is kept, when the target is skipped, and that `~/.claude/` and `~/.claude.json` — settings, MCP config, session history — are never touched.

### Testing

- `bash -n` clean; `shellcheck` shows **zero new findings** against the same command on `main`.
- Hermetic bash suite, 28 assertions, fake `$HOME` **with a space in the name**: absolute and relative symlinks, custom launcher, launcher outside `versions/`, missing launcher, dangling launcher, missing `versions/`, an open file held via `exec 9<`, subdirectories, "only the active version", dry-run (announces, deletes nothing), real run (old files gone, active file and symlink intact, reclaimed total exact), and both estimator branches.
- Real machine, read-only: `./dev-cleaner.sh --dry-run`, option 19 only — lists `2.1.252` and `2.1.257` (377.9 MiB), keeps `2.1.258`; estimator returns the same 377.9 MiB.

**Caveat:** `dev-cleaner.ps1` was written but not executed — no Windows or `pwsh` here. It was reviewed by hand against the existing Cordova/Electron/Docker ports, same as PRs #46-#48. The Windows paths come from the issue and from the official install-layout docs.

Out of scope, as the issue notes: the Desktop-managed runtime under `%APPDATA%\Claude\claude-code\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZxBtvDq8j2wDRKb9EEj8m
